### PR TITLE
invalidate s3 url cache upon storing file

### DIFF
--- a/lib/aws/s3/utils.py
+++ b/lib/aws/s3/utils.py
@@ -48,6 +48,9 @@ class S3Manager(object):
     def put_file(self, bucket_id, key_id, f):
         """Stores a file
         """
+        prekey = [bucket_id, key_id,]
+        c = S3UrlCache(prekey)
+        c.invalidate_cache()
         key = self._get_key(bucket_id, key_id)
         if key:
             bytes_written = key.set_contents_from_file(f)


### PR DESCRIPTION
this prevents future requests to the same s3 bucket/key to get the same s3 url that would hit the browser cache instead of retrieving the item anew
