### PR TITLE
make forms closer to HTML specs by setting field attributes, etc

### DIFF
--- a/apps/accounts/forms/update.py
+++ b/apps/accounts/forms/update.py
@@ -18,7 +18,7 @@ class UserUpdateForm(AbstractModelInstanceUpdateForm):
         user_profile = user.profile
         if not args and not kwargs:
             # override the displayed username value if not set by the user yet
-            # only do this for rendering a blank form (no request.POST)
+            # only do this for rendering a form initially (i.e. no request.POST)
             username_field_display_value = user.username if user_profile.has_username_set else ''
             user.username = username_field_display_value
         else:

--- a/forms/classes.py
+++ b/forms/classes.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from htk.forms.utils import set_input_attrs
 from htk.forms.utils import set_input_placeholder_labels
 
 class AbstractModelInstanceUpdateForm(forms.ModelForm):
@@ -33,10 +34,17 @@ class AbstractModelInstanceUpdateForm(forms.ModelForm):
         self.save_fields = save_fields
         save_fields_dict = dict(zip(save_fields, [True] * len(save_fields)))
         super(AbstractModelInstanceUpdateForm, self).__init__(instance=instance, *args, **kwargs)
-        # make all non-save fields optional
-        for name, field in self.fields.items():
-            if name not in save_fields_dict:
-                field.required = False
+        if args or kwargs:
+            # make all non-save fields optional
+            for name, field in self.fields.items():
+                if name not in save_fields_dict:
+                    field.required = False
+                else:
+                    pass
+        else:
+            # leave the fields the way they are for rendering a form initially
+            pass
+        set_input_attrs(self)
         set_input_placeholder_labels(self)
 
     def save(self, commit=True):

--- a/forms/utils.py
+++ b/forms/utils.py
@@ -31,6 +31,8 @@ def set_input_attrs(form, attrs=None):
     for name, field in form.fields.items():
         if field.widget.__class__ in TEXT_STYLE_INPUTS:
             field.widget.attrs['class'] = getattr(attrs, 'class', htk_setting('HTK_DEFAULT_FORM_INPUT_CLASS'))
+        if field.required:
+            field.widget.attrs['required'] = 'required'
 
 def set_input_placeholder_labels(form):
     """Set placeholder attribute to the field label on form input fields, if it doesn't have a placeholder set


### PR DESCRIPTION
don't override required attribute for rendering the form initially
