### PR TITLE
various json response improvements

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -4,24 +4,25 @@ import rollbar
 from time import mktime
 
 from django.core import serializers
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 from django.http import QueryDict
 
 from htk.api.constants import *
 
-class CustomJSONEncoder(json.JSONEncoder):
+class HtkJSONEncoder(serializers.json.DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             value = int(mktime(obj.timetuple()))
         else:
             try:
-                value = json.JSONEncoder.default(self, obj)
+                value = super(HtkJSONEncoder, self).default(obj)
             except:
                 rollbar.report_exc_info(extra_data={'obj': obj,})
                 value = -3.14159 # return an absurd value so that we know the object wasn't serializable
         return value
 
-def to_json(obj, encoder=CustomJSONEncoder):
+def to_json(obj, encoder=HtkJSONEncoder):
     if hasattr(obj, '_meta'):
         if hasattr(obj, '__contains__'):
             return serializers.serialize('json', obj )
@@ -42,14 +43,21 @@ def json_okay_str():
 def json_error_str():
     return to_json(json_error())
 
-def json_response(obj, encoder=CustomJSONEncoder):
-    return HttpResponse(to_json(obj, encoder=encoder), content_type='application/json')
+def json_response(obj, encoder=HtkJSONEncoder, status=200):
+    # TODO: consider the new django.http.response.JsonResponse in Django 1.7
+    # https://docs.djangoproject.com/en/1.7/ref/request-response/
+    response = HttpResponse(to_json(obj, encoder=encoder), content_type='application/json', status=status)
+    return response
 
 def json_response_okay():
-    return json_response(json_okay())
+    response = json_response(json_okay())
+    return response
 
-def json_response_error():
-    return json_response(json_error())
+def json_response_error(data=None, status=400):
+    if data is None:
+        data = json_error()
+    response = json_response(data, status=status)
+    return response
 
 def extract_post_params(post_data, expected_params, list_params=None, strict=True):
     """Extract `expected_params` from `post_data`


### PR DESCRIPTION
- `s/CustomJSONEncoder/HtkJSONEncoder/` and use DjangoJSONEncoder as base
- `json_response_error` allows custom data and 400 status code by default