### PR TITLE
Remove message when user is not allowed to emulate

### DIFF
--- a/admintools/middleware.py
+++ b/admintools/middleware.py
@@ -44,7 +44,7 @@ class HtkEmulateUserMiddleware(object):
                 # not attempting to emulate
                 pass
         else:
-            # is not allowed to emulate users
+            # is not allowed or is not attempting to emulate users
             pass
 
 

--- a/admintools/middleware.py
+++ b/admintools/middleware.py
@@ -44,7 +44,8 @@ class HtkEmulateUserMiddleware(object):
                 # not attempting to emulate
                 pass
         else:
-            messages.error(request, 'Cannot Emulate: Not allowed to emulate that user', fail_silently=True)
+            # is not allowed to emulate users
+            pass
 
 
     def process_response(self, request, response):


### PR DESCRIPTION
@jontsai We are messaging all the time for user's that aren't allowed to emulate. They should just simply pass through the middleware.