### PR TITLE
features/django-htk/encoding-unicode-ascii-characters

### DIFF
--- a/cache/classes.py
+++ b/cache/classes.py
@@ -186,7 +186,7 @@ class CustomCacheScheme(object):
 
         Can be overridden by the subclass
         """
-        key = '-'.join([x.encode("hex") for x in self.prekey])
+        key = '-'.join([str(x) if type(x) != 'unicode' else x.encode("hex") for x in self.prekey])
         return key
 
     def get_cache_key(self):

--- a/cache/classes.py
+++ b/cache/classes.py
@@ -180,9 +180,11 @@ class CustomCacheScheme(object):
         self._cache_key = None
 
     def get_unicode_characters_hex(self, x):
-        for index,value in enumerate(x):
-            if type(x) == 'unicode':
-                x[index] = ord(value)
+        for value in x:
+            if ord(value) > 128:
+                hex_value = hex(ord(value))
+                newvalue = "&#"+ hex_value +";"
+                x = x.replace(value, newvalue)
         return x
     
     def get_cache_key_suffix(self):

--- a/cache/classes.py
+++ b/cache/classes.py
@@ -186,7 +186,7 @@ class CustomCacheScheme(object):
 
         Can be overridden by the subclass
         """
-        key = '-'.join([x.encode('utf-8') for x in self.prekey])
+        key = '-'.join([x.encode("hex") for x in self.prekey])
         return key
 
     def get_cache_key(self):

--- a/cache/classes.py
+++ b/cache/classes.py
@@ -186,7 +186,7 @@ class CustomCacheScheme(object):
 
         Can be overridden by the subclass
         """
-        key = '-'.join([str(x) for x in self.prekey])
+        key = '-'.join([x.encode('utf-8') for x in self.prekey])
         return key
 
     def get_cache_key(self):

--- a/cache/classes.py
+++ b/cache/classes.py
@@ -180,9 +180,9 @@ class CustomCacheScheme(object):
         self._cache_key = None
 
     def get_unicode_characters_hex(self, x):
-        for value in x:
-            if(type(x) == 'unicode'):
-                value = ord(value)
+        for index,value in enumerate(x):
+            if type(x) == 'unicode':
+                x[index] = ord(value)
         return x
     
     def get_cache_key_suffix(self):

--- a/cache/classes.py
+++ b/cache/classes.py
@@ -179,6 +179,12 @@ class CustomCacheScheme(object):
             self.prekey = ['default',]
         self._cache_key = None
 
+    def get_unicode_characters_hex(self, x):
+        for value in x:
+            if(type(x) == 'unicode'):
+                value = ord(value)
+        return x
+    
     def get_cache_key_suffix(self):
         """Cache key suffix based on the prekey
 
@@ -186,7 +192,7 @@ class CustomCacheScheme(object):
 
         Can be overridden by the subclass
         """
-        key = '-'.join([str(x) if type(x) != 'unicode' else x.encode("hex") for x in self.prekey])
+        key = '-'.join([str(x) if type(x) != 'unicode' else self.get_unicode_characters_hex(x) for x in self.prekey])
         return key
 
     def get_cache_key(self):


### PR DESCRIPTION
Encoding Unicode ascii characters

This fix enables Unicode ascii's encoding with str() which were brought an error "UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 20: ordinal not in range(128)" to be encoded with 'utf-8'.