### PR TITLE
Make BaseStripeSubscription model Abstact

### DIFF
--- a/lib/stripe_lib/models.py
+++ b/lib/stripe_lib/models.py
@@ -466,6 +466,9 @@ class BaseStripeSubscription(BaseStripeModel):
     stripe_id = models.CharField(max_length=255, unique=True, null=True, blank=True)
     customer = models.ForeignKey(htk_setting('HTK_STRIPE_CUSTOMER_MODEL'), related_name='subscriptions')
 
+    class Meta:
+        abstract = True
+
     def create(self, price_or_plan, invoice=True):
         """Creates a new Subscription
 


### PR DESCRIPTION
Makes the model `BaseStripeSubscription` as `Abstract`