### PR TITLE
🎨 Add feature name to modal text

### DIFF
--- a/templates/htk/fragments/features/admin.html
+++ b/templates/htk/fragments/features/admin.html
@@ -6,7 +6,7 @@
       --red: #df6b51;
       --orange: #f9bc82;
     }
-    .features-wrapper {
+    .features-app .features-wrapper {
       display: flex;
       position: relative;
       margin: 2rem;
@@ -14,10 +14,10 @@
       flex-wrap: wrap;
       z-index: 900;
     }
-    .features-wrapper * {
+    .features-app .features-wrapper * {
       box-sizing: border-box;
     }
-    .feature {
+    .features-app .feature {
       display: flex;
       flex-direction: column;
       width: 32%;
@@ -26,16 +26,16 @@
       border: 1px solid var(--gray);
       border-radius: 4px;
     }
-    .feature-header {
+    .features-app .feature-header {
       display: flex;
     }
-    .feature h3 {
+    .features-app .feature h3 {
       position: relative;
       margin: 0;
       margin-bottom: 15px;
       flex-grow: 1;
     }
-    .feature h3::before {
+    .features-app .feature h3::before {
       content: "";
       display: inline-block;
       width: 10px;
@@ -44,17 +44,17 @@
       background-color: var(--gray);
       border-radius: 5px;
     }
-    .feature.on h3::before {
+    .features-app .feature.on h3::before {
       background-color: var(--green);
     }
-    .feature h3 span {
+    .features-app .feature h3 span {
       display: block;
       margin-left: 23px;
       font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
       font-size: 0.75em;
       font-weight: normal;
     }
-    .feature-switch {
+    .features-app .feature-switch {
       display: block;
       position: relative;
       width: 50px;
@@ -62,7 +62,7 @@
       background-color: var(--gray);
       border-radius: 13px;
     }
-    .feature-switch::after {
+    .features-app .feature-switch::after {
       content: "";
       display: block;
       position: absolute;
@@ -73,21 +73,21 @@
       border-radius: 10px;
       background-color: #FFFFFF;
     }
-    .feature.on .feature-switch {
+    .features-app .feature.on .feature-switch {
       background-color: var(--green);
     }
-    .feature.on .feature-switch::after {
+    .features-app .feature.on .feature-switch::after {
       left: initial;
       right: 3px;
     }
-    .feature-description {
+    .features-app .feature-description {
       flex-grow: 1;
     }
-    .feature-info {
+    .features-app .feature-info {
       display: flex;
       flex-wrap: wrap;
     }
-    .feature-info > div {
+    .features-app .feature-info > div {
       display: flex;
       justify-content: space-between;
       width: 50%;
@@ -95,7 +95,7 @@
       padding-right: 10px;
       box-sizing: border-box;
     }
-    .features-modal-container {
+    .features-app .features-modal-container {
       position: fixed;
       display: none;
       top: 0;
@@ -107,7 +107,7 @@
       background-color: var(--dark-gray);
       z-index: 1000;
     }
-    .features-modal {
+    .features-app .features-modal {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -116,7 +116,7 @@
       border-radius: 6px;
       background-color: #fff;
     }
-    .features-modal h1 {
+    .features-app .features-modal h1 {
       width: 80px;
       height: 80px;
       margin-bottom: 0.5rem;
@@ -126,16 +126,16 @@
       border: 2px solid var(--orange);
       border-radius: 50%;
     }
-    .features-modal h2 {
+    .features-app .features-modal h2 {
       margin-bottom: 0.5rem;
     }
-    .features-modal p {
+    .features-app .features-modal p {
       text-align: center;
     }
-    .features-modal-buttons {
+    .features-app .features-modal-buttons {
       margin: 1rem 0;
     }
-    button {
+    .features-app button {
       margin: 0 0.5rem;
       padding: 0.6rem 1rem;
       color: #fff;
@@ -147,32 +147,35 @@
       border-radius: 4px;
       transition: all 0.1s ease-in-out;
     }
-    button:hover {
+    .features-app button:hover {
       -webkit-box-shadow: 0px 0px 5px 0px var(--dark-gray);
       -moz-box-shadow: 0px 0px 5px 0px var(--dark-gray);
       box-shadow: 0px 0px 5px 0px var(--dark-gray);
     }
-    .disable-text {
+    .features-app .disable-text {
       display: none;
     }
-    .error-text {
+    .features-app .error-text {
       display: none;
       color: var(--red);
     }
-    .features-modal-container.disable .enable-text {
+    .features-app .features-modal-container.disable .enable-text {
       display: none;
     }
-    .features-modal-container.disable .disable-text {
+    .features-app .features-modal-container.disable .disable-text {
       display: initial;
     }
-    button.btn-confirm {
+    .features-app button.btn-confirm {
       background-color: var(--green);
     }
-    .features-modal-container.disable button.btn-confirm {
+    .features-app .features-modal-container.disable button.btn-confirm {
       background-color: var(--red);
     }
-    .features-modal-container.error .error-text {
+    .features-app .features-modal-container.error .error-text {
       display: block;
+    }
+    .features-app .features.modal-container .feature-name {
+      font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
     }
   </style>
   <div class="features-app">
@@ -180,7 +183,7 @@
       {% for feature_flag in feature_flags %}
       <div class="feature{% if feature_flag.is_enabled %} on{% endif %}" data-id="{{ feature_flag.id }}">
         <div class="feature-header">
-          <h3>
+          <h3 data-title="{{ feature_flag.title }}" data-name="{{ feature_flag.name }}">
             {{ feature_flag.title }}
             <span>{{ feature_flag.name }}</span>
           </h3>
@@ -204,8 +207,8 @@
       <div class="features-modal disable">
         <h1>!</h1>
         <h2>Are you sure?</h2>
-        <p class="enable-text">The feature <b class="feature-name"></b> will be <b>Enabled</b>.</p>
-        <p class="disable-text">The feature <b class="feature-name"></b> will be <b>Disabled</b>.</p>
+        <p class="enable-text">The feature <b class="feature-title"></b> (<b class="feature-name"></b>) will be <b>Enabled</b>.</p>
+        <p class="disable-text">The feature <b class="feature-title"></b> (<b class="feature-name"></b>) will be <b>Disabled</b>.</p>
         <p class="error-text">An error occured while trying to process the request.</p>
         <div class="features-modal-buttons">
           <button class="btn-close">Cancel</button>
@@ -231,7 +234,8 @@
         feature = $(this).closest('.feature');
         modal.removeClass('error')
         modal.toggleClass('disable', feature.hasClass('on'));
-        modal.find('.feature-name').text(feature.find('h3').text());
+        modal.find('.feature-title').text(feature.find('h3').data('title'));
+        modal.find('.feature-name').text(feature.find('h3').data('name'));
         modal.attr('style', 'display: flex;');
       });
 


### PR DESCRIPTION
- Features app toggle modal now shows Feature title as well as Feature name (unformatted)
- Feature name is being shown with `monospace` font.

Example: The Feature **Test Feature** (test_feature) will be **Enabled**.

Additional changes:
- All CSS definitions prefixed with `.features-app` to prevent breaking other elements
- Modal getting feature name and title from `data-name=""` and `data-title=""` attributes of `<h3 />` tag instead of text.