### PR TITLE
🩹 Fix typo and exclamation mark align on features view styling

### DIFF
--- a/templates/htk/fragments/features/admin.html
+++ b/templates/htk/fragments/features/admin.html
@@ -117,10 +117,13 @@
       background-color: #fff;
     }
     .features-app .features-modal h1 {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       width: 80px;
       height: 80px;
       margin-bottom: 0.5rem;
-      font-size: 3.3rem;
+      font-size: 48px;
       text-align: center;
       color: var(--orange);
       border: 2px solid var(--orange);
@@ -174,7 +177,7 @@
     .features-app .features-modal-container.error .error-text {
       display: block;
     }
-    .features-app .features.modal-container .feature-name {
+    .features-app .features .modal-container .feature-name {
       font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
     }
   </style>


### PR DESCRIPTION
- Fixed typo on `.feature-name` class
- Fixed exclamation mark align.