### PR TITLE
Return api error response

### DIFF
--- a/lib/dynamic_screening_solutions/api.py
+++ b/lib/dynamic_screening_solutions/api.py
@@ -133,15 +133,12 @@ class Htk321FormsAPI(object):
     def handle_response(self, response):
         try:
             response_json = response.json()
-            response_json = (
-                None
-                if type(response_json) == dict and response_json.get('error')
-                else response_json
-            )
+            is_bad_response = type(response_json) == dict and response_json.get('error')
         except ValueError:
-            response_json = None
+            is_bad_response = True
+            response_json = {}
 
-        if response_json is None:
+        if is_bad_response:
             self.handle_bad_response(response, response_json=response_json)
         else:
             pass


### PR DESCRIPTION
Currently, if api response is error handled to return `response_json` as `None`.

In this PR I handled to return error response so that user can be warned with the actual issue reported.
And also in Rollbar, the actual error will get reported.