### PR TITLE
Modify default string value of materialized property

### DIFF
--- a/apps/mp/services.py
+++ b/apps/mp/services.py
@@ -24,7 +24,7 @@ from htk.apps.mp.utils import format_model_name
 
 EXTRA_VERBOSITY = False
 
-MAGIC_VALUE_NOT_SET_STRING = '\0'
+MAGIC_VALUE_NOT_SET_STRING = ''
 
 registered_mps = defaultdict(dict)
 


### PR DESCRIPTION
In this PR modified the default string value used for materialized property defined as `CharField/TextField`.