### PR TITLE
Fix remove subscription return value

### DIFF
--- a/lib/stripe_lib/models.py
+++ b/lib/stripe_lib/models.py
@@ -544,8 +544,8 @@ class BaseStripeSubscription(BaseStripeModel):
 
         if subscription:
             args = (subscription.get('id'),)
-            _ = safe_stripe_call(self.STRIPE_API_CLASS.delete, *args)
-            was_deleted = True
+            obj = safe_stripe_call(self.STRIPE_API_CLASS.delete, *args)
+            was_deleted = obj is not None and obj.get('status') == 'canceled'
         else:
             was_deleted = False
 


### PR DESCRIPTION
Currently remove subscription return value is hard coded instead of processing from Stripe cancel api response.