### PR TITLE
update OrganizationInvitation signal handler for sending Slack messages

### DIFF
--- a/apps/organizations/apps.py
+++ b/apps/organizations/apps.py
@@ -31,6 +31,7 @@ def organization_invitation_created_or_updated(sender, instance, created, **kwar
             False: invitation.build_notification_message__declined,
             None: invitation.build_notification_message__resent,
         }
+
         msg_builder_key = 'created' if created else invitation.accepted
         msg_builder = INVITATION_ACCEPTANCE_MESSAGE_BUILDERS[msg_builder_key]
         msg = msg_builder()

--- a/apps/organizations/apps.py
+++ b/apps/organizations/apps.py
@@ -35,6 +35,7 @@ def organization_invitation_created_or_updated(sender, instance, created, **kwar
         msg_builder_key = 'created' if created else invitation.accepted
         msg_builder = INVITATION_ACCEPTANCE_MESSAGE_BUILDERS[msg_builder_key]
         msg = msg_builder()
+        
         try:
             slack_notify(msg)
         except Exception:

--- a/apps/organizations/apps.py
+++ b/apps/organizations/apps.py
@@ -20,7 +20,7 @@ from htk.utils import (
 
 @disable_for_loaddata
 def organization_invitation_created(sender, instance, created, **kwargs):
-    """Signal handler for when a new OrganizationInvitation object is created"""
+    """Signal handler for when a new OrganizationInvitation object is created or updated"""
     if created:
         invitation = instance
 
@@ -32,6 +32,34 @@ def organization_invitation_created(sender, instance, created, **kwargs):
                 slack_notify(msg)
             except:
                 rollbar.report_exc_info()
+    if created == False:
+        invitation = instance
+
+        if not settings.TEST and htk_setting('HTK_SLACK_NOTIFICATIONS_ENABLED'):
+            if invitation.accepted == True:
+                try:
+                    from htk.utils.notifications import slack_notify
+
+                    msg = invitation.build_notification_message__accepted()
+                    slack_notify(msg)
+                except:
+                    rollbar.report_exc_info()
+            if invitation.accepted == False:
+                try:
+                    from htk.utils.notifications import slack_notify
+
+                    msg = invitation.build_notification_message__declined()
+                    slack_notify(msg)
+                except:
+                    rollbar.report_exc_info()
+            if invitation.accepted == True:
+                try:
+                    from htk.utils.notifications import slack_notify
+
+                    msg = invitation.build_notification_message__resent()
+                    slack_notify(msg)
+                except:
+                    rollbar.report_exc_info()
 
 
 class HtkOrganizationAppConfig(HtkAppConfig):

--- a/apps/organizations/apps.py
+++ b/apps/organizations/apps.py
@@ -25,7 +25,7 @@ def organization_invitation_updated(sender, instance, created, **kwargs):
     if not settings.TEST and htk_setting('HTK_SLACK_NOTIFICATIONS_ENABLED'):
         from htk.utils.notifications import slack_notify
 
-        if created:
+        if created and msg is not None:
             msg = invitation.build_notification_message__created()
         else:
             INVITATION_ACCEPTANCE_MESSAGE_BUILDERS = {

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -321,17 +321,14 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
     ##
     # Notifications
 
-    User = get_user_model()
-
-    def _build_notification_message(self, subject: User, verb: str) -> str:
+    def _build_notification_message(self, subject, verb):
         """Builds a message that will be displayed as an internal Slack notification.
         """
-        msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_url}|{organization_name}>'.format( # noqa: E501
+        msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_name}>'.format( # noqa: E501
             verb=verb,
             subject_name=subject.profile.get_full_name(),
             subject_username=subject.username,
             email=subject.email,
-            organization_url=self.organization.profile_url,
             organization_name=self.organization.name,
         )
         return msg

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -320,18 +320,47 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
     ##
     # Notifications
 
+    def _build_notification_message(self, subject: User, verb: str) -> str:
+        """Builds a message that will be displayed as an internal Slack notification.
+        """
+        msg = '{subject_name} ({subject_username}<{subject_profile_url}|{email}>) has {verb} an invitation for Organization <{organization_url}|{organization_name}>'.format( # noqa: E501
+            verb=verb,
+            subject_name=subject.profile.get_full_name(),
+            subject_username=subject.username,
+            subject_profile_url=subject.profile.profile_url,
+            email=subject.email,
+            organization_url=self.organization.profile_url,
+            organization_name=self.organization.name,
+        )
+        return msg
+
     def build_notification_message__created(self):
         """Builds a message that will be displayed as an internal Slack notification
         when this invitation object is created.
         """
-        msg = '{invited_by_name} ({invited_by_username}) has sent an invitation for organization {organization_name} to {email}'.format(
-            invited_by_name=self.invited_by.profile.get_full_name(),
-            invited_by_username=self.invited_by.username,
-            organization_name=self.organization.name,
-            email=self.email,
-        )
+        msg = self._build_notification_message(self.invited_by, 'sent')
+        return msg
+    
+    def build_notification_message__accepted(self):
+        """Builds a message that will be displayed as an internal Slack notification
+        when this invitation object is accepted.
+        """
+        msg = self._build_notification_message(self.invited_by, 'accepted')
         return msg
 
+    def build_notification_message__declined(self):
+        """Builds a message that will be displayed as an internal Slack notification
+        when this invitation object is declined.
+        """
+        msg = self._build_notification_message(self.invited_by, 'declined')
+        return msg
+    
+    def build_notification_message__resent(self):
+        """Builds a message that will be displayed as an internal Slack notification
+        when this invitation object is re-sent.
+        """
+        msg = self._build_notification_message(self.invited_by, 're-sent')
+        return msg
 
 class BaseAbstractOrganizationTeam(HtkBaseModel):
     name = models.CharField(max_length=128)

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -322,8 +322,6 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
     # Notifications
 
     def _build_notification_message(self, subject, verb):
-        """Builds a message that will be displayed as an internal Slack notification.
-        """
         msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_name}>'.format( # noqa: E501
             verb=verb,
             subject_name=subject.profile.get_full_name(),
@@ -334,32 +332,21 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
         return msg
 
     def build_notification_message__created(self):
-        """Builds a message that will be displayed as an internal Slack notification
-        when this invitation object is created.
-        """
         msg = self._build_notification_message(self.invited_by, 'sent')
         return msg
-    
+
+    def build_notification_message__resent(self):
+        msg = self._build_notification_message(self.invited_by, 're-sent')
+        return msg
+
     def build_notification_message__accepted(self):
-        """Builds a message that will be displayed as an internal Slack notification
-        when this invitation object is accepted.
-        """
         msg = self._build_notification_message(self.user, 'accepted')
         return msg
 
     def build_notification_message__declined(self):
-        """Builds a message that will be displayed as an internal Slack notification
-        when this invitation object is declined.
-        """
         msg = self._build_notification_message(self.user, 'declined')
         return msg
-    
-    def build_notification_message__resent(self):
-        """Builds a message that will be displayed as an internal Slack notification
-        when this invitation object is re-sent.
-        """
-        msg = self._build_notification_message(self.invited_by, 're-sent')
-        return msg
+
 
 class BaseAbstractOrganizationTeam(HtkBaseModel):
     name = models.CharField(max_length=128)

--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -10,6 +10,7 @@ from typing import (
 # Django Imports
 from django.conf import settings
 from django.db import models
+from django.contrib.auth import get_user_model
 
 # HTK Imports
 from htk.apps.organizations.enums import (
@@ -320,14 +321,15 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
     ##
     # Notifications
 
+    User = get_user_model()
+
     def _build_notification_message(self, subject: User, verb: str) -> str:
         """Builds a message that will be displayed as an internal Slack notification.
         """
-        msg = '{subject_name} ({subject_username}<{subject_profile_url}|{email}>) has {verb} an invitation for Organization <{organization_url}|{organization_name}>'.format( # noqa: E501
+        msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_url}|{organization_name}>'.format( # noqa: E501
             verb=verb,
             subject_name=subject.profile.get_full_name(),
             subject_username=subject.username,
-            subject_profile_url=subject.profile.profile_url,
             email=subject.email,
             organization_url=self.organization.profile_url,
             organization_name=self.organization.name,
@@ -345,14 +347,14 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
         """Builds a message that will be displayed as an internal Slack notification
         when this invitation object is accepted.
         """
-        msg = self._build_notification_message(self.invited_by, 'accepted')
+        msg = self._build_notification_message(self.user, 'accepted')
         return msg
 
     def build_notification_message__declined(self):
         """Builds a message that will be displayed as an internal Slack notification
         when this invitation object is declined.
         """
-        msg = self._build_notification_message(self.invited_by, 'declined')
+        msg = self._build_notification_message(self.user, 'declined')
         return msg
     
     def build_notification_message__resent(self):

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -77,8 +77,8 @@ class OrganizationInvitationResponseView(View):
         self.invitation.accepted = invitation_response == 'accept'
         self.invitation.responded_at = timezone.datetime.now()
 
+        self.invitation.user = request.user
         if self.invitation.accepted:
-            self.invitation.user = request.user
             # TODO: adding as member but maybe this should be a setting?
             self.invitation.organization.add_member(
                 self.invitation.user, OrganizationMemberRoles.MEMBER


### PR DESCRIPTION
Updates the signal handler for `OrganizationInvitation` to send a Slack notification when an invitation is created, re-sent, accepted, or declined.