### PR TITLE
fix(JS Routes): 🐛 Fix serializer namespace defining

### DIFF
--- a/utils/js_route_serializer.py
+++ b/utils/js_route_serializer.py
@@ -98,8 +98,8 @@ def _parse_resolver(
     """
     defined_url_names = htk_setting('HTK_JS_ROUTES_URL_NAMES')
 
-    current_namespace = (
-        f'{namespace}:{resolver.namespace}' if namespace else resolver.namespace
+    current_namespace = ':'.join(
+        filter(lambda n: n, [namespace, resolver.namespace])
     )
     include_all = include_all or (current_namespace in defined_url_names)
 


### PR DESCRIPTION
## Status
**READY**

## Description
Due to a code structure, the namespaced routes names were generated like `namespace:none:urlName`.
This update fixes it and the output is corrected to `namespace:urlName`