### PR TITLE
fix: 🐛 basestring patch for python3

### DIFF
--- a/apps/mp/services.py
+++ b/apps/mp/services.py
@@ -29,6 +29,11 @@ MAGIC_VALUE_NOT_SET_STRING = '\0'
 
 registered_mps = defaultdict(dict)
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def materialized_property(
     field_definition,

--- a/lib/zillow/zestimate.py
+++ b/lib/zillow/zestimate.py
@@ -28,6 +28,12 @@ import warnings as warnings_
 from lxml import etree as etree_
 
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 Validate_simpletypes_ = True
 
 

--- a/lib/zillow/zillow_types.py
+++ b/lib/zillow/zillow_types.py
@@ -28,6 +28,12 @@ import warnings as warnings_
 from lxml import etree as etree_
 
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 Validate_simpletypes_ = True
 
 


### PR DESCRIPTION
## Status
**READY**

## Description
Patches `basestring` to make Python3 compatible