### PR TITLE
fix: 🐛 Make StringIO imports python 2 and 3 compatible

### DIFF
--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -1,7 +1,7 @@
 # Python Standard Library Imports
 import codecs
-import cStringIO
 import csv
+from six.moves import cStringIO
 
 
 class UTF8Recoder(object):
@@ -18,6 +18,7 @@ class UTF8Recoder(object):
 
     def next(self):
         return self.reader.next().encode('utf-8')
+
 
 class UnicodeReader(object):
     """
@@ -37,6 +38,7 @@ class UnicodeReader(object):
 
     def __iter__(self):
         return self
+
 
 class UnicodeWriter(object):
     """
@@ -69,6 +71,7 @@ class UnicodeWriter(object):
         for row in rows:
             self.writerow(row)
 
+
 def buffered_csv_from_collection(f, collection, row_generator, headings=None, utf8=True):
     """Buffers CSV to the stream `f`
     """
@@ -83,10 +86,12 @@ def buffered_csv_from_collection(f, collection, row_generator, headings=None, ut
     for item in collection:
         writer.writerow(row_generator(item))
 
+
 def get_csv_stringbuf_from_collection(collection, row_generator, headings=None, utf8=True):
     buf = cStringIO.StringIO()
     buffered_csv_from_collection(buf, collection, row_generator, headings=headings, utf8=utf8)
     return buf
+
 
 def get_csv_response_from_collection(collection, row_generator, headings=None, filename='data.csv', utf8=True):
     from django.http import HttpResponse
@@ -94,6 +99,7 @@ def get_csv_response_from_collection(collection, row_generator, headings=None, f
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
     buffered_csv_from_collection(response, collection, row_generator, headings=headings, utf8=utf8)
     return response
+
 
 class CSVDataExporter(object):
     def __init__(

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -120,11 +120,11 @@ def render_to_pdf_response_pisa(template_name, context_dict):
 
     PyPI: https://pypi.python.org/pypi/pisa/
     """
-    import cStringIO as StringIO
+    from six.moves import cStringIO as StringIO
     from xhtml2pdf import pisa
     html = generate_html_from_template(template_name, context_dict)
-    result = StringIO.StringIO()
-    pdf = pisa.pisaDocument(StringIO.StringIO(html.encode('utf-8')), result)
+    result = StringIO()
+    pdf = pisa.pisaDocument(StringIO(html.encode('utf-8')), result)
     if pdf:
         response = HttpResponse(result.getvalue(), mimetype='application/pdf')
     else:


### PR DESCRIPTION
## Status
**READY**

## Description
Fixed `cStringIO` imports to make it compatible with Python 2.x and Python 3.x

`cStringIO` module changed to `io.StringIO` in Python 3.

Used `six` package to import which is a compatibility layer for Python 2 and 3 apps.