### PR TITLE
refactor: ♻️ Make b64encode Python 2/3 compat

### DIFF
--- a/apps/accounts/utils/auth.py
+++ b/apps/accounts/utils/auth.py
@@ -1,5 +1,4 @@
 # Python Standard Library Imports
-import base64
 import datetime
 import hashlib
 import json
@@ -13,6 +12,7 @@ from django.contrib.auth import login
 # HTK Imports
 from htk.apps.accounts.utils import encrypt_uid
 from htk.apps.accounts.utils import resolve_encrypted_uid
+from htk.compat import b64decode, b64encode
 from htk.utils import htk_setting
 from htk.utils import utcnow
 from htk.utils.datetime_utils import datetime_to_unix_time
@@ -55,7 +55,7 @@ def get_user_token_auth_token(user, expires_minutes=None):
         'hash' : hashed,
     }
 
-    token = base64.b64encode(json.dumps(data).encode('utf-8')).decode('utf-8')
+    token = b64encode(json.dumps(data))
     return token
 
 
@@ -89,7 +89,7 @@ def validate_user_token_auth_token(token):
     is_valid = False
 
     try:
-        data = json.loads(base64.b64decode(token))
+        data = json.loads(b64decode(token))
     except ValueError:
         data = None
 

--- a/apps/accounts/utils/general.py
+++ b/apps/accounts/utils/general.py
@@ -1,5 +1,4 @@
 # Python Standard Library Imports
-import base64
 import hashlib
 import time
 from uuid import uuid4
@@ -20,6 +19,7 @@ from django.utils.http import (
 # HTK Imports
 from htk.apps.accounts.constants import *
 from htk.apps.accounts.exceptions import NonUniqueEmail
+from htk.compat import b64encode
 from htk.utils import htk_setting
 from htk.utils.general import resolve_model_dynamically
 from htk.utils.request import get_current_request
@@ -102,9 +102,10 @@ def email_to_username_hash(email):
     email = email.lower()
     # Deal with internationalized email addresses
     converted = email.encode('utf8', 'ignore')
-    hashed = base64.urlsafe_b64encode(
-        hashlib.sha256(converted).hexdigest().encode()
-    ).decode()[:EMAIL_TO_USERNAME_HASH_LENGTH]
+    hashed = b64encode(
+        hashlib.sha256(converted).hexdigest(),
+        url_safe=True
+    )[:EMAIL_TO_USERNAME_HASH_LENGTH]
     return hashed
 
 

--- a/apps/async_task/utils.py
+++ b/apps/async_task/utils.py
@@ -8,21 +8,34 @@ def build_async_task_result(content, content_type, filename):
 
     This is necessary if we want to return multiple values, as the result by default is just a plain string.
     """
+    b64encoded_content = base64.b64encode(content.encode('utf-8'))
+
+    # Python 2 returns ``str`` and Python 3 returns ``bytes``
+    if isinstance(b64encoded_content, bytes):
+        b64encoded_content = b64encoded_content.decode('utf-8')
+
     payload = {
-        'content' : base64.b64encode(content),
-        'content_type' : content_type,
-        'filename' : filename,
+        'content': b64encoded_content,
+        'content_type': content_type,
+        'filename': filename,
     }
     result = json.dumps(payload)
     return result
 
+
 def extract_async_task_result_json_values(result_data):
-    """Companion function to perform the inverse of `build_async_task_result()`
-    """
+    """Companion function to perform the inverse of `build_async_task_result()`"""
     payload = json.loads(result_data)
 
-    content = base64.b64decode(payload['content'])
+    content = base64.b64decode(payload['content'].encode('utf-8'))
+    if isinstance(content, bytes):
+        content = content.decode('utf-8')
+
     content_type = payload['content_type']
     filename = payload['filename']
 
-    return (content, content_type, filename,)
+    return (
+        content,
+        content_type,
+        filename,
+    )

--- a/apps/async_task/utils.py
+++ b/apps/async_task/utils.py
@@ -1,6 +1,8 @@
 # Python Standard Library Imports
-import base64
 import json
+
+# HTK Imports
+from htk.compat import b64encode, b64decode
 
 
 def build_async_task_result(content, content_type, filename):
@@ -8,18 +10,13 @@ def build_async_task_result(content, content_type, filename):
 
     This is necessary if we want to return multiple values, as the result by default is just a plain string.
     """
-    b64encoded_content = base64.b64encode(content.encode('utf-8'))
-
-    # Python 2 returns ``str`` and Python 3 returns ``bytes``
-    if isinstance(b64encoded_content, bytes):
-        b64encoded_content = b64encoded_content.decode('utf-8')
-
     payload = {
-        'content': b64encoded_content,
+        'content': b64encode(content),
         'content_type': content_type,
         'filename': filename,
     }
     result = json.dumps(payload)
+
     return result
 
 
@@ -27,9 +24,7 @@ def extract_async_task_result_json_values(result_data):
     """Companion function to perform the inverse of `build_async_task_result()`"""
     payload = json.loads(result_data)
 
-    content = base64.b64decode(payload['content'].encode('utf-8'))
-    if isinstance(content, bytes):
-        content = content.decode('utf-8')
+    content = b64decode(payload['content'])
 
     content_type = payload['content_type']
     filename = payload['filename']

--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,41 @@
+# Python Standard Library Imports
+import base64
+
+# Third Party (PyPI) Imports
+from six import text_type
+
+
+def b64encode(content, url_safe=False):
+    """Base64 encoder with Python 2/3 compatibility
+
+    Args:
+        content: str | unicode | bytes
+        url_safe: bool
+
+    Return: str
+    """
+    encoder = base64.urlsafe_b64encode if url_safe else base64.b64encode
+
+    content = content.encode()
+    encoded = encoder(content)
+    encoded = encoded.decode() if isinstance(encoded, bytes) else encoded
+
+    return encoded
+
+
+def b64decode(content, url_safe=False):
+    """Base64 decoder with Python 2/3 compability
+
+    Args:
+        content: str | unicode | bytes
+        url_safe: bool
+
+    Return: str
+    """
+    decoder = base64.urlsafe_b64decode if url_safe else base64.b64decode
+
+    content = content.encode() if isinstance(content, text_type) else content
+    decoded = decoder(content)
+    decoded = decoded.decode() if isinstance(decoded, bytes) else decoded
+
+    return decoded

--- a/lib/dynamic_screening_solutions/api.py
+++ b/lib/dynamic_screening_solutions/api.py
@@ -62,7 +62,7 @@ class Htk321FormsAPI(object):
         )
         signature = base64.b64encode(
             hmac.new(
-                bytes(secret_key), base_string, digestmod=hashlib.sha1
+                secret_key.encode('utf-8'), base_string.encode('utf-8'), digestmod=hashlib.sha1
             ).digest()
         )
         return signature

--- a/lib/dynamic_screening_solutions/api.py
+++ b/lib/dynamic_screening_solutions/api.py
@@ -53,16 +53,16 @@ class Htk321FormsAPI(object):
 
         Secret key-hashed Base64
         """
-        import base64
+        from htk.compat import b64encode
 
         base_string = '{"Username":"%s","SentDate":"%s","Action":"%s"}' % (
             headers['Username'],
             headers['SentDate'],
             headers['Action'],
         )
-        signature = base64.b64encode(
+        signature = b64encode(
             hmac.new(
-                secret_key.encode('utf-8'), base_string.encode('utf-8'), digestmod=hashlib.sha1
+                secret_key.encode(), base_string.encode(), digestmod=hashlib.sha1
             ).digest()
         )
         return signature

--- a/lib/dynamic_screening_solutions/utils.py
+++ b/lib/dynamic_screening_solutions/utils.py
@@ -1,10 +1,10 @@
 # Python Standard Library Imports
-import base64
 import hashlib
 import hmac
 import json
 
 # HTK Imports
+from htk.compat import b64encode
 from htk.utils import htk_setting
 from htk.utils.general import resolve_method_dynamically
 
@@ -24,10 +24,10 @@ def validate_webhook_request(request):
     hash_key_retriever = resolve_method_dynamically(htk_setting('HTK_321FORMS_WEBHOOK_HASH_KEY_RETRIEVER'))
     hash_key = hash_key_retriever(company_id)
 
-    signature = base64.b64encode(
+    signature = b64encode(
         hmac.new(
-            hash_key.encode('utf-8'),
-            request.body.encode('utf-8'),
+            hash_key.encode(),
+            request.body.encode(),
             digestmod=hashlib.sha1
         ).digest()
     )

--- a/lib/dynamic_screening_solutions/utils.py
+++ b/lib/dynamic_screening_solutions/utils.py
@@ -26,8 +26,8 @@ def validate_webhook_request(request):
 
     signature = base64.b64encode(
         hmac.new(
-            bytes(hash_key),
-            request.body,
+            hash_key.encode('utf-8'),
+            request.body.encode('utf-8'),
             digestmod=hashlib.sha1
         ).digest()
     )

--- a/lib/fitbit/api.py
+++ b/lib/fitbit/api.py
@@ -55,7 +55,10 @@ class FitbitAPI(object):
         if auth_type == 'bearer':
             auth_header = 'Bearer %s' % self.social_auth_user.extra_data['access_token']
         else:
-            auth_header = 'Basic %s' % base64.b64encode('%s:%s' % (self.client_id, self.client_secret,))
+            basic_value = '%s:%s' % (self.client_id, self.client_secret,)
+            auth_header = 'Basic %s' % base64.b64encode(basic_value.encode('utf-8'))
+            if isinstance(auth_header, bytes):
+                auth_header = auth_header.decode('utf-8')
         _headers = {
             'Authorization' : auth_header,
             'Accept-Locale' : 'en_US',

--- a/lib/fitbit/api.py
+++ b/lib/fitbit/api.py
@@ -1,11 +1,9 @@
-# Python Standard Library Imports
-import base64
-
 # Third Party (PyPI) Imports
 import requests
 import rollbar
 
 # HTK Imports
+from htk.compat import b64encode
 from htk.lib.fitbit.constants import *
 from htk.utils import refresh
 from htk.utils import utcnow
@@ -56,7 +54,7 @@ class FitbitAPI(object):
             auth_header = 'Bearer %s' % self.social_auth_user.extra_data['access_token']
         else:
             basic_value = '%s:%s' % (self.client_id, self.client_secret,)
-            auth_header = 'Basic %s' % base64.b64encode(basic_value.encode('utf-8'))
+            auth_header = 'Basic %s' % b64encode(basic_value)
             if isinstance(auth_header, bytes):
                 auth_header = auth_header.decode('utf-8')
         _headers = {

--- a/lib/google/gmail/api.py
+++ b/lib/google/gmail/api.py
@@ -1,11 +1,8 @@
-# Python Standard Library Imports
-import base64
-import time
-
 # Third Party (PyPI) Imports
 import requests
 
 # HTK Imports
+from htk.compat import b64decode
 from htk.lib.google.gmail.constants import GMAIL_RESOURCES
 from htk.utils import refresh
 from htk.utils.cache_descriptors import CachedAttribute
@@ -412,7 +409,7 @@ class GmailMessage(object):
 
         if html_part:
             message_body_data = html_part['body']['data']
-            message_html = base64.b64decode(message_body_data.replace('-', '+').replace('_', '/'))
+            message_html = b64decode(message_body_data.replace('-', '+').replace('_', '/'))
         else:
             message_html = None
 
@@ -459,7 +456,7 @@ class GmailMessage(object):
 
         if text_part:
             message_body_data = text_part['body']['data']
-            message_text = base64.b64decode(message_body_data.replace('-', '+').replace('_', '/')).decode('utf-8')
+            message_text = b64decode(message_body_data.replace('-', '+').replace('_', '/'))
         else:
             # fallback to HTML
             message_text = self.get_html()

--- a/lib/zillow/zestimate.py
+++ b/lib/zillow/zestimate.py
@@ -76,7 +76,11 @@ except ImportError as exp:
             else:
                 return input_data
         def gds_format_base64(self, input_data, input_name=''):
-            return base64.b64encode(input_data)
+            value = base64.b64encode(input_data.encode('utf-8'))
+            if isinstance(value, bytes):
+                value = value.decode('utf-8')
+            return value
+
         def gds_validate_base64(self, input_data, node=None, input_name=''):
             return input_data
         def gds_format_integer(self, input_data, input_name=''):
@@ -537,8 +541,11 @@ class MixedContainer:
             outfile.write('<%s>%g</%s>' % (
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
-            outfile.write('<%s>%s</%s>' % (
-                self.name, base64.b64encode(self.value), self.name))
+            value = base64.b64encode(self.value.encode('utf-8'))
+            if isinstance(value, bytes):
+                value = value.decode('utf-8')
+            outfile.write('<%s>%s</%s>' % (self.name, value, self.name))
+
     def to_etree(self, element):
         if self.category == MixedContainer.CategoryText:
             # Prevent exporting empty content as empty lines.

--- a/lib/zillow/zestimate.py
+++ b/lib/zillow/zestimate.py
@@ -18,7 +18,6 @@
 #
 
 # Python Standard Library Imports
-import base64
 import datetime as datetime_
 import re as re_
 import sys
@@ -26,6 +25,9 @@ import warnings as warnings_
 
 # Third Party (PyPI) Imports
 from lxml import etree as etree_
+
+# HTK Imports
+from htk.compat import b64encode
 
 
 try:
@@ -76,7 +78,7 @@ except ImportError as exp:
             else:
                 return input_data
         def gds_format_base64(self, input_data, input_name=''):
-            value = base64.b64encode(input_data.encode('utf-8'))
+            value = b64encode(input_data)
             if isinstance(value, bytes):
                 value = value.decode('utf-8')
             return value
@@ -541,7 +543,7 @@ class MixedContainer:
             outfile.write('<%s>%g</%s>' % (
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
-            value = base64.b64encode(self.value.encode('utf-8'))
+            value = b64encode(self.value)
             if isinstance(value, bytes):
                 value = value.decode('utf-8')
             outfile.write('<%s>%s</%s>' % (self.name, value, self.name))
@@ -577,7 +579,7 @@ class MixedContainer:
         elif self.content_type == MixedContainer.TypeDouble:
             text = '%g' % self.value
         elif self.content_type == MixedContainer.TypeBase64:
-            text = '%s' % base64.b64encode(self.value)
+            text = '%s' % b64encode(self.value)
         return text
     def exportLiteral(self, outfile, level, name):
         if self.category == MixedContainer.CategoryText:

--- a/lib/zillow/zillow_types.py
+++ b/lib/zillow/zillow_types.py
@@ -75,8 +75,15 @@ except ImportError as exp:
                 return ''
             else:
                 return input_data
+
         def gds_format_base64(self, input_data, input_name=''):
-            return base64.b64encode(input_data)
+            value = base64.b64encode(input_data.encode('utf-8'))
+
+            if isinstance(value, bytes):
+                value = value.decode('utf-8')
+
+            return value
+
         def gds_validate_base64(self, input_data, node=None, input_name=''):
             return input_data
         def gds_format_integer(self, input_data, input_name=''):
@@ -537,8 +544,12 @@ class MixedContainer:
             outfile.write('<%s>%g</%s>' % (
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
-            outfile.write('<%s>%s</%s>' % (
-                self.name, base64.b64encode(self.value), self.name))
+            value = base64.b64encode(self.value)
+            if isinstance(value, bytes):
+                value = value.decode('utf-8')
+
+            outfile.write('<%s>%s</%s>' % (self.name, value, self.name))
+
     def to_etree(self, element):
         if self.category == MixedContainer.CategoryText:
             # Prevent exporting empty content as empty lines.

--- a/lib/zillow/zillow_types.py
+++ b/lib/zillow/zillow_types.py
@@ -80,10 +80,6 @@ except ImportError as exp:
 
         def gds_format_base64(self, input_data, input_name=''):
             value = b64encode(input_data)
-
-            if isinstance(value, bytes):
-                value = value.decode('utf-8')
-
             return value
 
         def gds_validate_base64(self, input_data, node=None, input_name=''):
@@ -547,9 +543,6 @@ class MixedContainer:
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
             value = b64encode(self.value)
-            if isinstance(value, bytes):
-                value = value.decode('utf-8')
-
             outfile.write('<%s>%s</%s>' % (self.name, value, self.name))
 
     def to_etree(self, element):

--- a/lib/zillow/zillow_types.py
+++ b/lib/zillow/zillow_types.py
@@ -18,7 +18,6 @@
 #
 
 # Python Standard Library Imports
-import base64
 import datetime as datetime_
 import re as re_
 import sys
@@ -26,6 +25,9 @@ import warnings as warnings_
 
 # Third Party (PyPI) Imports
 from lxml import etree as etree_
+
+# HTK Imports
+from htk.compat import b64encode
 
 
 try:
@@ -77,7 +79,7 @@ except ImportError as exp:
                 return input_data
 
         def gds_format_base64(self, input_data, input_name=''):
-            value = base64.b64encode(input_data.encode('utf-8'))
+            value = b64encode(input_data)
 
             if isinstance(value, bytes):
                 value = value.decode('utf-8')
@@ -544,7 +546,7 @@ class MixedContainer:
             outfile.write('<%s>%g</%s>' % (
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
-            value = base64.b64encode(self.value)
+            value = b64encode(self.value)
             if isinstance(value, bytes):
                 value = value.decode('utf-8')
 
@@ -581,7 +583,7 @@ class MixedContainer:
         elif self.content_type == MixedContainer.TypeDouble:
             text = '%g' % self.value
         elif self.content_type == MixedContainer.TypeBase64:
-            text = '%s' % base64.b64encode(self.value)
+            text = '%s' % b64encode(self.value)
         return text
     def exportLiteral(self, outfile, level, name):
         if self.category == MixedContainer.CategoryText:

--- a/templatetags/htk_tags.py
+++ b/templatetags/htk_tags.py
@@ -16,6 +16,12 @@ from django.utils.safestring import (
     mark_safe,
 )
 
+# HTK Imports
+from htk.compat import (
+    b64decode,
+    b64encode,
+)
+
 
 register = template.Library()
 
@@ -95,7 +101,7 @@ def atob(value):
     """Base64 decode
     ASCII to Binary
     """
-    value = base64.b64decode(value)
+    value = b64decode(value)
     return value
 
 
@@ -107,12 +113,7 @@ def btoa(value):
     if type(value) in (str, SafeText):
         value = value.encode('utf-8')
 
-    value = base64.b64encode(value)
-
-    # b64encode return str in python2 but bytes in python3
-    if isinstance(value, bytes):
-        # Convert bytes to str for for use in template
-        value = value.decode('utf-8')
+    value = b64encode(value)
 
     return value
 

--- a/templatetags/htk_tags.py
+++ b/templatetags/htk_tags.py
@@ -107,8 +107,13 @@ def btoa(value):
     if type(value) in (str, SafeText):
         value = value.encode('utf-8')
 
-    # Convert bytes to str for for use in template
-    value = base64.b64encode(value).decode('utf-8')
+    value = base64.b64encode(value)
+
+    # b64encode return str in python2 but bytes in python3
+    if isinstance(value, bytes):
+        # Convert bytes to str for for use in template
+        value = value.decode('utf-8')
+
     return value
 
 

--- a/templatetags/urlizer.py
+++ b/templatetags/urlizer.py
@@ -12,14 +12,21 @@ from htk.utils import htk_setting
 
 register = template.Library()
 
+
 @register.simple_tag
 def redir_url(url):
     redir_view = htk_setting('HTK_REDIRECT_URL_NAME')
+
+    encoded_url = base64.urlsafe_b64encode(url.encode('utf-8'))
+    if isinstance(encoded_url, bytes):
+        encoded_url = encoded_url.decode('utf-8')
+
     url = '%(path)s?url=%(url)s' % {
-        'path' : reverse(redir_view),
-        'url' : base64.urlsafe_b64encode(url.encode()).decode(),
+        'path': reverse(redir_view),
+        'url': encoded_url
     }
     return url
+
 
 @register.simple_tag
 def redir(url, text=None, target='_blank'):
@@ -33,6 +40,7 @@ def redir(url, text=None, target='_blank'):
     }
     html = mark_safe(html)
     return html
+
 
 @register.simple_tag
 def redir_trunc(url, length, target='_blank'):

--- a/templatetags/urlizer.py
+++ b/templatetags/urlizer.py
@@ -1,12 +1,10 @@
-# Python Standard Library Imports
-import base64
-
 # Django Imports
 from django import template
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 # HTK Imports
+from htk.compat import b64encode
 from htk.utils import htk_setting
 
 
@@ -17,9 +15,7 @@ register = template.Library()
 def redir_url(url):
     redir_view = htk_setting('HTK_REDIRECT_URL_NAME')
 
-    encoded_url = base64.urlsafe_b64encode(url.encode('utf-8'))
-    if isinstance(encoded_url, bytes):
-        encoded_url = encoded_url.decode('utf-8')
+    encoded_url = b64encode(url, url_safe=True)
 
     url = '%(path)s?url=%(url)s' % {
         'path': reverse(redir_view),
@@ -34,9 +30,9 @@ def redir(url, text=None, target='_blank'):
     """
     text = text or url
     html = '<a href="%(url)s" target="%(target)s">%(text)s</a>' % {
-        'url' : redir_url(url),
-        'text' : text,
-        'target' : target,
+        'url': redir_url(url),
+        'text': text,
+        'target': target,
     }
     html = mark_safe(html)
     return html

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -1,10 +1,15 @@
 # Python Standard Library Imports
-import base64
 import hashlib
 
 # Third Party (PyPI) Imports
 from Crypto import Random
 from Crypto.Cipher import AES
+
+# HTK Imports
+from htk.compat import (
+    b64decode,
+    b64encode,
+)
 
 
 # TODO: This needs to be refactored.
@@ -21,10 +26,10 @@ class AESCipher(object):
         raw = self._pad(raw)
         iv = Random.new().read(AES.block_size)
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
-        return base64.b64encode(iv + cipher.encrypt(raw.encode()))
+        return b64encode(iv + cipher.encrypt(raw.encode()))
 
     def decrypt(self, enc):
-        enc = base64.b64decode(enc)
+        enc = b64decode(enc)
         iv = enc[:AES.block_size]
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
         return self._unpad(cipher.decrypt(enc[AES.block_size:])).decode('utf-8')

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -7,6 +7,7 @@ from Crypto import Random
 from Crypto.Cipher import AES
 
 
+# TODO: This needs to be refactored.
 class AESCipher(object):
     """Class for encrypting and decrypting data using AES256
 

--- a/views.py
+++ b/views.py
@@ -1,5 +1,4 @@
 # Python Standard Library Imports
-import base64
 import re
 
 # Django Imports
@@ -18,6 +17,7 @@ from django.template import (
 from django.urls import reverse
 
 # HTK Imports
+from htk.compat import b64decode
 from htk.utils import htk_setting
 
 
@@ -151,7 +151,7 @@ def redir(request):
     encoded_url = request.GET.get('url', None)
     if encoded_url:
         try:
-            url = base64.urlsafe_b64decode(str(encoded_url))
+            url = b64decode(str(encoded_url), url_safe=True)
             if not re.match('^https?://', url):
                 url = 'http://%s' % url
             else:


### PR DESCRIPTION
## Status
**READY**

## Description
`base64.b64encode` requires encoded `bytes` in Python 3 but it works with `str` in Python 2.
The result of this function is `bytes` in Python 3 and `str` in Python 2.

Encoding the data with `utf-8` before passing to `base64.b64encode` works both for Python 2 and 3.
If the returning value is `bytes` (this only happens with Python 3) it needs to be decoded with `utf-8`