### PR TITLE
fix: 🐛 321Forms webhook event hasher

### DIFF
--- a/apps/changelog/management/commands/changelog.py
+++ b/apps/changelog/management/commands/changelog.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 # Django 1 and >2 compatible import
 try:
     # Django Imports
-    from django.urls import reverse
+    from django.core.urlresolvers import reverse
 except ImportError:
     from django.urls import reverse
 

--- a/apps/changelog/management/commands/changelog.py
+++ b/apps/changelog/management/commands/changelog.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 # Django 1 and >2 compatible import
 try:
     # Django Imports
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
 except ImportError:
     from django.urls import reverse
 

--- a/compat.py
+++ b/compat.py
@@ -9,7 +9,7 @@ def is_python2():
 
 
 def is_python3():
-    is_python2 = sys.version_info.major == 3
+    is_python3 = sys.version_info.major == 3
     return is_python3
 
 

--- a/lib/dynamic_screening_solutions/utils.py
+++ b/lib/dynamic_screening_solutions/utils.py
@@ -27,8 +27,7 @@ def validate_webhook_request(request):
     hash_key_retriever = resolve_method_dynamically(htk_setting('HTK_321FORMS_WEBHOOK_HASH_KEY_RETRIEVER'))
     hash_key = hash_key_retriever(company_id)
 
-    # According to Rollbar error, `hash_key` can be `None`. `hmac.new` does not
-    # do well with `None` value for both Python 2 and 3
+    # `hash_key` can be `None`. `hmac.new` does not do well with `None` value for both Python 2 and 3
     if hash_key:
         hash_key = hash_key.encode() if IS_PYTHON_3 else hash_key
         request_body = request.body.encode() if IS_PYTHON_3 else request.body

--- a/lib/dynamic_screening_solutions/utils.py
+++ b/lib/dynamic_screening_solutions/utils.py
@@ -4,7 +4,10 @@ import hmac
 import json
 
 # HTK Imports
-from htk.compat import b64encode
+from htk.compat import (
+    IS_PYTHON_3,
+    b64encode,
+)
 from htk.utils import htk_setting
 from htk.utils.general import resolve_method_dynamically
 
@@ -24,15 +27,20 @@ def validate_webhook_request(request):
     hash_key_retriever = resolve_method_dynamically(htk_setting('HTK_321FORMS_WEBHOOK_HASH_KEY_RETRIEVER'))
     hash_key = hash_key_retriever(company_id)
 
-    signature = b64encode(
-        hmac.new(
-            hash_key.encode(),
-            request.body.encode(),
-            digestmod=hashlib.sha1
-        ).digest()
-    )
+    # According to Rollbar error, `hash_key` can be `None`. `hmac.new` does not
+    # do well with `None` value for both Python 2 and 3
+    if hash_key:
+        hash_key = hash_key.encode() if IS_PYTHON_3 else hash_key
+        request_body = request.body.encode() if IS_PYTHON_3 else request.body
 
-    is_valid = signature == expected_signature
+        hashed = hmac.new(hash_key, request_body, diggestmod=hashlib.sha1).digest()
+
+        signature = b64encode(hashed)
+
+        is_valid = signature == expected_signature
+    else:
+        is_valid = False
+
     if is_valid:
         webhook_data = webhook_data
     else:


### PR DESCRIPTION
## Status
**READY**

## Description
- Fixes a typo in `compat.py`
- Fixes a sad path in 321 webhook request validator.
- Makes the `hmac.new` Python 2/3 compatible. (It accepts `bytes` for 1st and 2nd arguments)

It seems, there are times that `hash_key` is None. The code before was not handling that correctly.