### PR TITLE
fix: 🐛 Convert the hash_key to bytes in Python 2

### DIFF
--- a/lib/dynamic_screening_solutions/utils.py
+++ b/lib/dynamic_screening_solutions/utils.py
@@ -29,7 +29,11 @@ def validate_webhook_request(request):
 
     # `hash_key` can be `None`. `hmac.new` does not do well with `None` value for both Python 2 and 3
     if hash_key:
-        hash_key = hash_key.encode() if IS_PYTHON_3 else hash_key
+        # Even for Python 2 it seems we need to convert the hash_key to bytes.
+        # REFERENCES:
+        # https://bugs.python.org/issue16063
+        # https://stackoverflow.com/a/31572219
+        hash_key = hash_key.encode() if IS_PYTHON_3 else bytes(hash_key)
         request_body = request.body.encode() if IS_PYTHON_3 else request.body
 
         hashed = hmac.new(hash_key, request_body, digestmod=hashlib.sha1).digest()


### PR DESCRIPTION
## Status
**READY**

## Description
- Fixed `hash_key` type for Python 2

## Testing
Did an extensive testing:

### Python 2

1. First tried with `str`:

```sh
>>> key = 'some-hard-to-guess-key'
>>> msg = 'some-importang-msg-to-hash-or-something'
>>> hmac.new(key, msg, digestmod=hashlib.sha1).digest()
']h\x94\\\xd7\xda\xc7oM\x08!J\xcc\x93\xdb.`\x87\xc2\xb1'
```

2. Tried with only making `key` `unicode`:

```sh
>>> key = u'some-hard-to-guess-key'
>>> hmac.new(key, msg, digestmod=hashlib.sha1).digest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/hmac.py", line 136, in new
    return HMAC(key, msg, digestmod)
  File "/usr/lib/python2.7/hmac.py", line 75, in __init__
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode
```

3. Tried with making only `msg` a `unicode`:

```sh
>>> key = 'some-hard-to-guess-key'
>>> msg = u'some-importang-msg-to-hash-or-something'
>>> hmac.new(key, msg, digestmod=hashlib.sha1).digest()
']h\x94\\\xd7\xda\xc7oM\x08!J\xcc\x93\xdb.`\x87\xc2\xb1'
```

4. Used `bytes` function on `unicode` `key`:

```sh
>>> key = bytes(u'some-hard-to-guess-key')
>>> hmac.new(key, msg, digestmod=hashlib.sha1).digest()
']h\x94\\\xd7\xda\xc7oM\x08!J\xcc\x93\xdb.`\x87\xc2\xb1
```

5. To make sure, passed `str` to `bytes` function:

```sh
>>> key = bytes('some-hard-to-guess-key')
>>> hmac.new(key, msg, digestmod=hashlib.sha1).digest()
']h\x94\\\xd7\xda\xc7oM\x08!J\xcc\x93\xdb.`\x87\xc2\xb1
```