### PR TITLE
refactor: ♻️ AESCipher Python 2/3 compatability

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -25,7 +25,7 @@ IS_PYTHON_2 = is_python2()
 IS_PYTHON_3 = is_python3()
 
 
-def b64encode(content, url_safe=False):
+def b64encode(content, url_safe=False, as_str=True):
     """Base64 encoder with Python 2/3 compatibility
 
     Args:
@@ -44,13 +44,14 @@ def b64encode(content, url_safe=False):
     )
     encoded = encoder(content)
 
-    # The result of Python 3 `base64.b64encode` is `bytes`, but we always want a `str`
-    encoded = encoded.decode() if IS_PYTHON_3 else encoded
+    # The result of Python 3 `base64.b64encode` is `bytes` but,
+    # most of the time we want a `str`.
+    encoded = encoded.decode() if IS_PYTHON_3 and as_str else encoded
 
     return encoded
 
 
-def b64decode(encoded, url_safe=False):
+def b64decode(encoded, url_safe=False, as_str=True):
     """Base64 decoder with Python 2/3 compability
 
     Args:
@@ -64,7 +65,8 @@ def b64decode(encoded, url_safe=False):
     # `base64.b64decode` can decode either `str` or `bytes`, so no pre-treatment needed
     decoded = decoder(encoded)
 
-    # The result of Python 3 `base64.b64decode` is `bytes`, but we always want a `str`
-    decoded = decoded.decode() if IS_PYTHON_3 else decoded
+    # The result of Python 3 `base64.b64decode` is `bytes` but,
+    # most of the time we want a `str`.
+    decoded = decoded.decode() if IS_PYTHON_3 and as_str else decoded
 
     return decoded

--- a/compat.py
+++ b/compat.py
@@ -31,8 +31,11 @@ def b64encode(content, url_safe=False, as_str=True):
     Args:
         content: str | unicode (Python 2 only) | bytes (Python 3 only)
         url_safe: bool
+        as_str: bool
+            When `True` (default), converts the encoded result to a `str` for convenience.
+            When `False`, the result is preseved as `bytes`
 
-    Returns: str
+    Returns: str if as_str else bytes
     """
     encoder = base64.urlsafe_b64encode if url_safe else base64.b64encode
 
@@ -57,8 +60,11 @@ def b64decode(encoded, url_safe=False, as_str=True):
     Args:
         encoded: str | unicode | bytes
         url_safe: bool
+        as_str: bool
+            When `True` (default), converts the encoded result to a `str` for convenience.
+            When `False`, the result is preseved as `bytes`
 
-    Returns: str
+    Returns: str if as_str else bytes
     """
     decoder = base64.urlsafe_b64decode if url_safe else base64.b64decode
 

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -1,4 +1,5 @@
 # Python Standard Library Imports
+import base64
 import hashlib
 
 # Third Party (PyPI) Imports
@@ -6,10 +7,7 @@ from Crypto import Random
 from Crypto.Cipher import AES
 
 # HTK Imports
-from htk.compat import (
-    b64decode,
-    b64encode,
-)
+from htk.compat import b64encode
 
 
 # TODO: This needs to be refactored.
@@ -18,25 +16,33 @@ class AESCipher(object):
 
     Source: https://stackoverflow.com/a/21928790/865091
     """
+
+    bs = AES.block_size
+
     def __init__(self, key):
-        self.bs = AES.block_size
         self.key = hashlib.sha256(key.encode()).digest()
 
     def encrypt(self, raw):
         raw = self._pad(raw)
-        iv = Random.new().read(AES.block_size)
+        iv = Random.new().read(self.bs)
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
-        return b64encode(iv + cipher.encrypt(raw.encode()))
+        encoded = b64encode(iv + cipher.encrypt(raw.encode()))
+        return encoded
 
     def decrypt(self, enc):
-        enc = b64decode(enc)
-        iv = enc[:AES.block_size]
+        # base64 encoded data is not convertable to `str` so not using `htk.compat.b64decode`
+        enc = base64.b64decode(enc)
+        iv = enc[:self.bs]
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
-        return self._unpad(cipher.decrypt(enc[AES.block_size:])).decode('utf-8')
+        decrypted = self._unpad(cipher.decrypt(enc[self.bs:])).decode('utf-8')
+        return decrypted
 
-    def _pad(self, s):
-        return s + (self.bs - len(s) % self.bs) * chr(self.bs - len(s) % self.bs)
+    @classmethod
+    def _pad(cls, s):
+        padded = s + (cls.bs - len(s) % cls.bs) * chr(cls.bs - len(s) % cls.bs)
+        return padded
 
-    @staticmethod
-    def _unpad(s):
-        return s[:-ord(s[len(s)-1:])]
+    @classmethod
+    def _unpad(cls, s):
+        unpadded = s[: -ord(s[len(s) - 1:])]
+        return unpadded

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -30,7 +30,7 @@ class AESCipher(object):
         return encoded
 
     def decrypt(self, enc):
-        # base64 encoded data is not convertable to `str` so not using `htk.compat.b64decode`
+        # base64 encoded data is not convertible to `str` so not using `htk.compat.b64decode`
         enc = base64.b64decode(enc)
         iv = enc[:self.bs]
         cipher = AES.new(self.key, AES.MODE_CBC, iv)

--- a/utils/crypto.py
+++ b/utils/crypto.py
@@ -1,5 +1,4 @@
 # Python Standard Library Imports
-import base64
 import hashlib
 
 # Third Party (PyPI) Imports
@@ -7,7 +6,10 @@ from Crypto import Random
 from Crypto.Cipher import AES
 
 # HTK Imports
-from htk.compat import b64encode
+from htk.compat import (
+    b64decode,
+    b64encode,
+)
 
 
 # TODO: This needs to be refactored.
@@ -30,8 +32,10 @@ class AESCipher(object):
         return encoded
 
     def decrypt(self, enc):
-        # base64 encoded data is not convertible to `str` so not using `htk.compat.b64decode`
-        enc = base64.b64decode(enc)
+        # encrypted data cannot be converted to `str` after base64 decoding
+        # the decoded base64 result must remain as `bytes`
+        enc = b64decode(enc, as_str=False)
+
         iv = enc[:self.bs]
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
         decrypted = self._unpad(cipher.decrypt(enc[self.bs:])).decode('utf-8')
@@ -44,5 +48,5 @@ class AESCipher(object):
 
     @classmethod
     def _unpad(cls, s):
-        unpadded = s[: -ord(s[len(s) - 1:])]
+        unpadded = s[:-ord(s[len(s) - 1:])]
         return unpadded


### PR DESCRIPTION
## Status
**READY**

## Description
- Fixed `decrypt` method of `AESCipher` to make it compatible with Python 3.

It was decoding with `base64.b64decode` in Python 2. I updated it to `htk.compat.b64decode` but it needs to stay as bytes for `decrypt`ing to work.

**NOTE:** Tested with Python 2.7 and Python 3.9