### PR TITLE
Fix issue module collections compatible for Python 2 and Python 3

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -1,5 +1,4 @@
 # Python Standard Library Imports
-import collections
 import hashlib
 import uuid
 from typing import (
@@ -7,10 +6,13 @@ from typing import (
     Dict,
 )
 
+# Third Party (PyPI) Imports
+from six.moves import collections_abc
+
 # Django Imports
 from django.conf import settings
-from django.db import models
 from django.contrib.auth import get_user_model
+from django.db import models
 
 # HTK Imports
 from htk.apps.organizations.enums import (
@@ -103,7 +105,7 @@ class BaseAbstractOrganization(HtkBaseModel, GoogleOrganizationMixin):
     def get_distinct_members(self):
         members = self.get_members()
 
-        if not hasattr(collections, 'MutableSet'):
+        if not hasattr(collections_abc, 'MutableSet'):
             # Python >= 3.6
             # See:
             # - https://stackoverflow.com/a/53657523/865091
@@ -322,7 +324,7 @@ class BaseAbstractOrganizationInvitation(HtkBaseModel):
     # Notifications
 
     def _build_notification_message(self, subject, verb):
-        msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_name}>'.format( # noqa: E501
+        msg = '{subject_name} ({subject_username}<{email}>) has {verb} an invitation for Organization <{organization_name}>'.format(  # noqa: E501
             verb=verb,
             subject_name=subject.profile.get_full_name(),
             subject_username=subject.username,

--- a/extensions/data_structures/ordered_set.py
+++ b/extensions/data_structures/ordered_set.py
@@ -1,9 +1,8 @@
+# Third Party (PyPI) Imports
+from six.moves import collections_abc
 
-# Python Standard Library Imports
-import collections
 
-
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections_abc.MutableSet):
     """
     From: https://code.activestate.com/recipes/576694/
      Official Python docs also recommended it: https://docs.python.org/2/library/collections.html#collections.OrderedDict

--- a/utils/cache_descriptors.py
+++ b/utils/cache_descriptors.py
@@ -1,7 +1,9 @@
 # Python Standard Library Imports
-import collections
 import functools
 import types
+
+# Third Party (PyPI) Imports
+from six.moves import collections_abc
 
 
 class memoized(object):
@@ -16,7 +18,7 @@ class memoized(object):
         self.cache = {}
 
     def __call__(self, *args):
-        if not isinstance(args, collections.Hashable):
+        if not isinstance(args, collections_abc.Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.
             return self.func(*args)


### PR DESCRIPTION
The issue is importing modules of `Collections` differs based on Python version.

Used library `six`  for Python 2 and 3 compatability.