### PR TITLE
Fix UUID has no attribute `get_hex`

### DIFF
--- a/apps/accounts/utils/general.py
+++ b/apps/accounts/utils/general.py
@@ -58,7 +58,7 @@ def create_user(
     UserModel = get_user_model()
 
     if username_prefix and isinstance(username_prefix, str):
-        username = '%s_%s' % (username_prefix, uuid4().get_hex()[:10],)
+        username = '%s_%s' % (username_prefix, uuid4().hex[:10],)
     else:
         username = email_to_username_pretty_unique(email)
 
@@ -85,7 +85,7 @@ def set_random_password(user, password_length=16):
 
     Utilizes hex UUID
     """
-    password = uuid4().get_hex()[:password_length]
+    password = uuid4().hex[:password_length]
     user.set_password(password)
     user.save()
     return password

--- a/apps/accounts/utils/general.py
+++ b/apps/accounts/utils/general.py
@@ -1,7 +1,6 @@
 # Python Standard Library Imports
 import hashlib
 import time
-from uuid import uuid4
 
 # Third Party (PyPI) Imports
 import rollbar
@@ -19,7 +18,10 @@ from django.utils.http import (
 # HTK Imports
 from htk.apps.accounts.constants import *
 from htk.apps.accounts.exceptions import NonUniqueEmail
-from htk.compat import b64encode
+from htk.compat import (
+    b64encode,
+    uuid4_hex
+)
 from htk.utils import htk_setting
 from htk.utils.general import resolve_model_dynamically
 from htk.utils.request import get_current_request
@@ -58,7 +60,7 @@ def create_user(
     UserModel = get_user_model()
 
     if username_prefix and isinstance(username_prefix, str):
-        username = '%s_%s' % (username_prefix, uuid4().hex[:10],)
+        username = '%s_%s' % (username_prefix, uuid4_hex()[:10],)
     else:
         username = email_to_username_pretty_unique(email)
 
@@ -85,7 +87,7 @@ def set_random_password(user, password_length=16):
 
     Utilizes hex UUID
     """
-    password = uuid4().hex[:password_length]
+    password = uuid4_hex()[:password_length]
     user.set_password(password)
     user.save()
     return password

--- a/compat.py
+++ b/compat.py
@@ -1,6 +1,7 @@
 # Python Standard Library Imports
 import base64
 import sys
+import uuid
 
 
 def is_python2():
@@ -76,3 +77,8 @@ def b64decode(encoded, url_safe=False, as_str=True):
     decoded = decoded.decode() if IS_PYTHON_3 and as_str else decoded
 
     return decoded
+
+
+def uuid4_hex():
+    """Python 2/3 compatible uuid4() hex generator"""
+    return uuid.uuid4().hex if IS_PYTHON_3 else uuid.uuid4().get_hex()

--- a/lib/slack/beacon/utils.py
+++ b/lib/slack/beacon/utils.py
@@ -2,6 +2,7 @@
 from django.urls import reverse
 
 # HTK Imports
+from htk.compat import uuid4_hex
 from htk.utils import htk_setting
 
 
@@ -10,9 +11,8 @@ def create_slack_beacon(event):
     webhook_settings = event.get('webhook_settings', {})
     slack_webhook_url = webhook_settings.get('slack_webhook_url')
     if slack_webhook_url:
-        from uuid import uuid4
         from htk.lib.slack.beacon.cachekeys import SlackBeaconCache
-        beacon_key = uuid4().hex[:6]
+        beacon_key = uuid4_hex()[:6]
         payload = {
             'slack_webhook_url' : slack_webhook_url,
             'channel_name' : event.get('channel_name'),

--- a/lib/slack/beacon/utils.py
+++ b/lib/slack/beacon/utils.py
@@ -12,7 +12,7 @@ def create_slack_beacon(event):
     if slack_webhook_url:
         from uuid import uuid4
         from htk.lib.slack.beacon.cachekeys import SlackBeaconCache
-        beacon_key = uuid4().get_hex()[:6]
+        beacon_key = uuid4().hex[:6]
         payload = {
             'slack_webhook_url' : slack_webhook_url,
             'channel_name' : event.get('channel_name'),

--- a/test_scaffold/utils.py
+++ b/test_scaffold/utils.py
@@ -1,11 +1,11 @@
 # Python Standard Library Imports
 import random
-from uuid import uuid4
 
 # Django Imports
 from django.contrib.auth import get_user_model
 
 # HTK Imports
+from htk.compat import uuid4_hex
 from htk.test_scaffold.test_data import *
 
 
@@ -14,13 +14,13 @@ def create_test_user():
     If two randomly assigned usernames overlap, it will fail
     """
     UserModel = get_user_model()
-    username = '%s_%s' % ('test', uuid4().hex[:10],)
+    username = '%s_%s' % ('test', uuid4_hex()[:10],)
     user = UserModel.objects.create(username=username)
     return user
 
 def create_test_email():
     email = 'test%s@%s' % (
-        uuid4().hex[:10],
+        uuid4_hex()[:10],
         'hacktoolkit.com',
     )
     return email
@@ -28,11 +28,11 @@ def create_test_email():
 def create_test_username():
     """Generates a random username
     """
-    username = '%s_%s' % ('test', uuid4().hex[:10],)
+    username = '%s_%s' % ('test', uuid4_hex()[:10],)
     return username
 
 def create_test_password():
-    password = uuid4().hex
+    password = uuid4_hex()
     return password
 
 def create_test_user_with_email_and_password():
@@ -53,7 +53,7 @@ def get_test_username():
     return username
 
 def get_random_string(max_length=0):
-    s = 'randstr%s' % uuid4().hex
+    s = 'randstr%s' % uuid4_hex()
     if max_length > 0:
         s = s[:max_length]
     return s

--- a/test_scaffold/utils.py
+++ b/test_scaffold/utils.py
@@ -14,13 +14,13 @@ def create_test_user():
     If two randomly assigned usernames overlap, it will fail
     """
     UserModel = get_user_model()
-    username = '%s_%s' % ('test', uuid4().get_hex()[:10],)
+    username = '%s_%s' % ('test', uuid4().hex[:10],)
     user = UserModel.objects.create(username=username)
     return user
 
 def create_test_email():
     email = 'test%s@%s' % (
-        uuid4().get_hex()[:10],
+        uuid4().hex[:10],
         'hacktoolkit.com',
     )
     return email
@@ -28,11 +28,11 @@ def create_test_email():
 def create_test_username():
     """Generates a random username
     """
-    username = '%s_%s' % ('test', uuid4().get_hex()[:10],)
+    username = '%s_%s' % ('test', uuid4().hex[:10],)
     return username
 
 def create_test_password():
-    password = uuid4().get_hex()
+    password = uuid4().hex
     return password
 
 def create_test_user_with_email_and_password():
@@ -53,7 +53,7 @@ def get_test_username():
     return username
 
 def get_random_string(max_length=0):
-    s = 'randstr%s' % uuid4().get_hex()
+    s = 'randstr%s' % uuid4().hex
     if max_length > 0:
         s = s[:max_length]
     return s


### PR DESCRIPTION
This PR fixes the issue `'UUID' object has no attribute 'get_hex'`.

In Python 2 `UUID` has method `get_hex()` which doesn't exist in Python 3.
Instead, the `hex` attribute should be used.

A Python 2/3 compatibility util, `uuid4_hex`, is introduced, to allow inter-operability.