### PR TITLE
fix: 🐛 HttpErrorResponseMiddleware

### DIFF
--- a/middleware/classes.py
+++ b/middleware/classes.py
@@ -136,6 +136,13 @@ class HttpErrorResponseMiddleware:
     instead.
     """
 
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
     def process_exception(self, request, exception):
         if isinstance(exception, HttpErrorResponseError):
             response = exception.response


### PR DESCRIPTION
## Description
- Fixes `htk.middleware.classes.HttpErrorResponseMiddleware` by adding missing required methods.