### PR TITLE
Remove already canceled subscriptions

### DIFF
--- a/lib/stripe_lib/models.py
+++ b/lib/stripe_lib/models.py
@@ -593,9 +593,15 @@ class BaseStripeSubscription(BaseStripeModel):
         subscription = self.retrieve()
 
         if subscription:
-            args = (subscription.get('id'),)
-            obj = safe_stripe_call(self.STRIPE_API_CLASS.delete, *args)
-            was_deleted = obj is not None and obj.get('status') == 'canceled'
+            # Subscription `status` set to `canceled` already
+            # may be due to `Stripe Payment Failure` or other reasons
+            was_deleted = subscription.get('status') == 'canceled'
+
+            # Subscription is `active` and should be deleted
+            if not was_deleted:
+                args = (subscription.get('id'),)
+                obj = safe_stripe_call(self.STRIPE_API_CLASS.delete, *args)
+                was_deleted = obj is not None and obj.get('status') == 'canceled'
         else:
             was_deleted = False
 


### PR DESCRIPTION
Handle to remove already `canceled` Stripe subscriptions that happened may be due to `Stripe Payment Failure` or other reasons.