### PR TITLE
feat: ✨ Make file blob contents editable

### DIFF
--- a/apps/blob_storage/models.py
+++ b/apps/blob_storage/models.py
@@ -14,7 +14,8 @@ class AbstractBlobStorage(models.Model):
     content_type = models.CharField(max_length=64, blank=True)
     size_bytes = models.PositiveIntegerField(default=0)
     contents = CompressedBinaryField(
-        max_length=htk_setting('HTK_BLOB_CONTENT_MAX_LENGTH')
+        max_length=htk_setting('HTK_BLOB_CONTENT_MAX_LENGTH'),
+        editable=True
     )
 
     class Meta:


### PR DESCRIPTION
To make the files editable in the Django admin this small addition needed.
`editable` option is `False` by default for `BinaryField`