### PR TITLE
feat: ✨ upgrade generate_nav_links view helper

### DIFF
--- a/view_helpers.py
+++ b/view_helpers.py
@@ -492,7 +492,9 @@ def generate_nav_links(request, nav_links_cfg):
         submenu = link_cfg.get('submenu', None)
         cfg_url_name = link_cfg.get('url_name', None)
         if cfg_url_name:
-            nav_link['uri'] = reverse(cfg_url_name)
+            args = link_cfg.get('url_args', [])
+            kwargs = link_cfg.get('url_kwargs', {})
+            nav_link['uri'] = reverse(cfg_url_name, args=args, kwargs=kwargs)
         else:
             pass
         selected = url_name == cfg_url_name


### PR DESCRIPTION
## Description
an upgrade to pass `args` or `kwargs` to `reverse` function.

Solves the following case:

URL definition:
```python
from django.urls import re_path

urlpatterns = [
    re_path(r'^(?P<type>privacy|tos)$', ..., name='policy')
]
```

Usage:
```python
from htk.view_helpers import generate_nav_links

generate_nav_links([
    {
        'text': 'Privacy Policy',
        'url_name': 'policies:policy',
        'args': ('privacy',),
    },
    {
        'text': 'Terms of Service',
        'url_name': 'policies:policy',
        'args': ('tos',),
    },
])
```