### PR TITLE
fix: 🔧 changes `early access` notification channel from `p4` to `p5` for dev and test servers

### DIFF
--- a/apps/prelaunch/models/base.py
+++ b/apps/prelaunch/models/base.py
@@ -169,7 +169,7 @@ class BasePrelaunchSignup(models.Model):
             'Early access has been enabled for {} <{}>'.format(
                 self.full_name, self.email
             ),
-            level='info',
+            level='debug',
         )
 
         try:

--- a/apps/prelaunch/models/base.py
+++ b/apps/prelaunch/models/base.py
@@ -15,7 +15,7 @@ from htk.apps.prelaunch.emails import (
     prelaunch_email,
 )
 from htk.utils import htk_setting
-from htk.utils.notifications import notify
+from htk.utils.notifications import slack_notify
 from htk.utils.request import get_current_request
 
 
@@ -139,8 +139,6 @@ class BasePrelaunchSignup(models.Model):
 
     def send_notifications(self):
         if htk_setting('HTK_SLACK_NOTIFICATIONS_ENABLED'):
-            from htk.utils.notifications import slack_notify
-
             try:
                 slack_notify(self.notification_message)
             except:
@@ -165,11 +163,11 @@ class BasePrelaunchSignup(models.Model):
         self.early_access = True
         self.early_access_code = uuid.uuid4().hex
         self.save()
-        notify(
+        slack_notify(
             'Early access has been enabled for {} <{}>'.format(
                 self.full_name, self.email
             ),
-            level='debug',
+            level='info',
         )
 
         try:

--- a/apps/prelaunch/models/base.py
+++ b/apps/prelaunch/models/base.py
@@ -15,7 +15,7 @@ from htk.apps.prelaunch.emails import (
     prelaunch_email,
 )
 from htk.utils import htk_setting
-from htk.utils.notifications import slack_notify
+from htk.utils.notifications import notify
 from htk.utils.request import get_current_request
 
 
@@ -139,6 +139,8 @@ class BasePrelaunchSignup(models.Model):
 
     def send_notifications(self):
         if htk_setting('HTK_SLACK_NOTIFICATIONS_ENABLED'):
+            from htk.utils.notifications import slack_notify
+
             try:
                 slack_notify(self.notification_message)
             except:
@@ -163,13 +165,11 @@ class BasePrelaunchSignup(models.Model):
         self.early_access = True
         self.early_access_code = uuid.uuid4().hex
         self.save()
-        slack_notify(
+        notify(
             'Early access has been enabled for {} <{}>'.format(
                 self.full_name, self.email
-            ),
-            level='info',
+            )
         )
-
         try:
             early_access_email(self)
         except Exception:

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -57,11 +57,9 @@ def slack_notify(message, level=None):
 
     try:
         channels = htk_setting('HTK_SLACK_NOTIFICATION_CHANNELS')
-
         default_level = (
             'debug' if (settings.ENV_DEV or settings.TEST) else 'info'
         )
-
         level = (
             default_level
             if level not in channels

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -57,10 +57,17 @@ def slack_notify(message, level=None):
 
     try:
         channels = htk_setting('HTK_SLACK_NOTIFICATION_CHANNELS')
+
         default_level = (
             'debug' if (settings.ENV_DEV or settings.TEST) else 'info'
         )
-        level = level if level in channels else default_level
+
+        level = (
+            default_level
+            if level not in channels
+            else ('debug' if (settings.ENV_DEV or settings.TEST) else level)
+        )
+
         channel = channels.get(level, htk_setting('HTK_SLACK_DEBUG_CHANNEL'))
         slack_webhook_call(text=message, channel=channel)
     except:

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -60,12 +60,7 @@ def slack_notify(message, level=None):
         default_level = (
             'debug' if (settings.ENV_DEV or settings.TEST) else 'info'
         )
-        level = (
-            default_level
-            if level not in channels
-            else ('debug' if (settings.ENV_DEV or settings.TEST) else level)
-        )
-
+        level = level if level in channels else default_level
         channel = channels.get(level, htk_setting('HTK_SLACK_DEBUG_CHANNEL'))
         slack_webhook_call(text=message, channel=channel)
     except:


### PR DESCRIPTION
## Description:
- Removes the explicit level `info` and uses the default level `debug` for the early access notification. 
- Default notification level: https://github.com/hacktoolkit/django-htk/blob/a3043a0dc859282f35827bb1dbd2cd81fd17eec1/utils/notifications.py#L37-L39