### PR TITLE
fix: 🔧 modifies `as_dict` model method in the `reactions` model

### DIFF
--- a/apps/conversations/models.py
+++ b/apps/conversations/models.py
@@ -230,7 +230,7 @@ class BaseConversationMessageReaction(models.Model):
 
     def as_dict(self):
         value = {
-            'user': self.user.as_dict(),
+            'user': self.user,
             'emoji_shortcode': self.emoji_shortcode,
             'created_at': self.created_at,
         }

--- a/apps/conversations/models.py
+++ b/apps/conversations/models.py
@@ -230,7 +230,7 @@ class BaseConversationMessageReaction(models.Model):
 
     def as_dict(self):
         value = {
-            'user': self.user,
+            'user': self.user.profile.as_dict(),
             'emoji_shortcode': self.emoji_shortcode,
             'created_at': self.created_at,
         }


### PR DESCRIPTION
## Description
- Uses the `as_dict` method with a `user.profile` instead of `user` in the `ConversationReaction`s model. 