### PR TITLE
feat: add ability to recognize early access code in header

### DIFF
--- a/apps/prelaunch/utils.py
+++ b/apps/prelaunch/utils.py
@@ -101,6 +101,8 @@ def get_early_access_code(request):
         request.GET.get(key)
         or request.COOKIES.get(key)
         or request.session.get(key)
+        # `early_access_code` key is not being recognized in the headers
+        or request.headers.get('Early-Access-Code')
     )
     return early_access_code
 

--- a/apps/prelaunch/utils.py
+++ b/apps/prelaunch/utils.py
@@ -102,7 +102,7 @@ def get_early_access_code(request):
         or request.COOKIES.get(key)
         or request.session.get(key)
         # `early_access_code` key is not being recognized in the headers
-        or request.headers.get('Early-Access-Code')
+        or request.headers.get('X-HTK-Early-Access-Code')
     )
     return early_access_code
 

--- a/apps/prelaunch/utils.py
+++ b/apps/prelaunch/utils.py
@@ -97,12 +97,12 @@ def is_prelaunch_exception_view(path):
 
 def get_early_access_code(request):
     key = 'early_access_code'
+    header = 'X-HTK-Early-Access-Code'
     early_access_code = (
         request.GET.get(key)
         or request.COOKIES.get(key)
         or request.session.get(key)
-        # `early_access_code` key is not being recognized in the headers
-        or request.headers.get('X-HTK-Early-Access-Code')
+        or request.headers.get(header)
     )
     return early_access_code
 


### PR DESCRIPTION
## Description
Django cannot receive cookie data from the react-native environment.
Instead of adding it as a query-parameter on every request, sending it in the header was better.
This PR updates the `get_early_access_code` helper function to also get the early access code from header.