### PR TITLE
fix: 🔧 adds `blob` max size to main constants

### DIFF
--- a/constants/defaults.py
+++ b/constants/defaults.py
@@ -93,6 +93,7 @@ HTK_JS_ROUTES_DYNAMIC_PART_PLACEHOLDER = '{0}'
 from htk.admintools.constants.defaults import *
 from htk.apps.accounts.constants.defaults import *
 from htk.apps.bible.constants.defaults import *
+from htk.apps.blob_storage.constants.defaults import *
 from htk.apps.changelog.constants.defaults import *
 from htk.apps.conversations.constants.defaults import *
 from htk.apps.cpq.constants.defaults import *


### PR DESCRIPTION
- Adds missing blob constant https://github.com/hacktoolkit/django-htk/blob/2ba2a0a6467c06ec5c308c9267ad43d553232750/apps/blob_storage/constants/defaults.py import in the main constants `defaults` file used by `htk_setting`. 
- Allows other apps to successfully use the `setting` for `'HTK_BLOB_CONTENT_MAX_LENGTH'`