### PR TITLE
fix: 🔧 `profile user` reference in `is_organization_member`

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -506,7 +506,7 @@ class BaseAbstractUserProfile(
         return organizations
 
     def is_organization_member(self, organization):
-        is_member = organization.has_member(user)
+        is_member = organization.has_member(self.user)
         return is_member
 
     ##


### PR DESCRIPTION
- Fixes a typo with the reference to the `profile user` when checking if the user is a member of an `organization`.