### PR TITLE
feat: ✨ adds a custom channel parameter to `slack_notify`

### DIFF
--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -48,10 +48,11 @@ def notify(message, level=None, use_messages=True, use_slack=None):
         slack_notify(message, level=level)
 
 
-def slack_notify(message, level=None):
+def slack_notify(message, level=None, custom_channel=None):
     """Send a Slack notification message
 
     `level` is one of ['critical', 'severe', 'danger', 'warning', 'info', 'debug',]
+    `custom_channel` is a string of a custom Slack channel name
     """
     from htk.lib.slack.utils import webhook_call as slack_webhook_call
 
@@ -61,7 +62,7 @@ def slack_notify(message, level=None):
             'debug' if (settings.ENV_DEV or settings.TEST) else 'info'
         )
         level = level if level in channels else default_level
-        channel = channels.get(level, htk_setting('HTK_SLACK_DEBUG_CHANNEL'))
+        channel = custom_channel or channels.get(level, htk_setting('HTK_SLACK_DEBUG_CHANNEL'))
         slack_webhook_call(text=message, channel=channel)
     except:
         request = get_current_request()


### PR DESCRIPTION
- Adds a new parameter to specify a custom Slack channel for sending the message, which takes precedence over other configured levels.