### PR TITLE
feat: ✨ adds a `RequestTooBig` Middleware to detect large request bodies

### DIFF
--- a/middleware/__init__.py
+++ b/middleware/__init__.py
@@ -2,6 +2,7 @@
 from htk.middleware.classes import (
     AllowedHostsMiddleware,
     GlobalRequestMiddleware,
+    RequestDataTooBigMiddleware,
     RequestTimerMiddleware,
     RewriteJsonResponseContentTypeMiddleware,
     TimezoneMiddleware,
@@ -12,6 +13,7 @@ from htk.middleware.classes import (
 __all__ = [
     'AllowedHostsMiddleware',
     'GlobalRequestMiddleware',
+    'RequestDataTooBigMiddleware',
     'RequestTimerMiddleware',
     'RewriteJsonResponseContentTypeMiddleware',
     'TimezoneMiddleware',

--- a/middleware/classes.py
+++ b/middleware/classes.py
@@ -1,19 +1,24 @@
-# Third Party (PyPI) Imports
-from user_agents import parse as parse_user_agent
-
 # Python Standard Library Imports
 import re
 import sys
 
+# Third Party (PyPI) Imports
+from user_agents import parse as parse_user_agent
+
 # Django Imports
+from django.core.exceptions import RequestDataTooBig
 from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 
 # HTK Imports
+from htk.api.utils import json_response_error
 from htk.utils import htk_setting
 from htk.utils.http.errors import HttpErrorResponseError
-from htk.utils.request import is_allowed_host
+from htk.utils.request import (
+    is_ajax_request,
+    is_allowed_host,
+)
 
 
 is_py2 = sys.version[0] == '2'
@@ -29,6 +34,7 @@ class GlobalRequestMiddleware(MiddlewareMixin):
     Makes an assumption that one request runs entirely in one thread
     If a request happens to spin off other threads, I suppose the request object would not be accessible
     """
+
     _threadmap = {}
 
     @classmethod
@@ -60,6 +66,7 @@ class AllowedHostsMiddleware(MiddlewareMixin):
 
     If host ends with '.', will redirect to host with '.' stripped
     """
+
     def process_request(self, request):
         host = request.get_host()
         request_path = request.path
@@ -68,17 +75,25 @@ class AllowedHostsMiddleware(MiddlewareMixin):
         if request_path == '/health_check':
             return False
         elif not is_allowed_host(host):
-            redirect_uri = 'http%s://%s%s' % (https_prefix, htk_setting('HTK_DEFAULT_DOMAIN'), request_path,)
+            redirect_uri = 'http%s://%s%s' % (
+                https_prefix,
+                htk_setting('HTK_DEFAULT_DOMAIN'),
+                request_path,
+            )
         elif len(host) > 1 and host[-1] == '.':
-            redirect_uri = 'http%s://%s%s' % (https_prefix, host[:-1], request_path,)
+            redirect_uri = 'http%s://%s%s' % (
+                https_prefix,
+                host[:-1],
+                request_path,
+            )
 
         if redirect_uri:
             return redirect(redirect_uri)
 
 
 class RequestTimerMiddleware(MiddlewareMixin):
-    """Timer to observe how long a request takes to process
-    """
+    """Timer to observe how long a request takes to process"""
+
     _threadmap = {}
 
     @classmethod
@@ -103,8 +118,11 @@ class RewriteJsonResponseContentTypeMiddleware(MiddlewareMixin):
     """This middleware exists because IE is a stupid browser and tries to
     download application/json content type from XHR responses as file
     """
+
     def process_response(self, request, response):
-        if self._is_response_json(response) and self._is_user_agent_msie(request):
+        if self._is_response_json(response) and self._is_user_agent_msie(
+            request
+        ):
             response['Content-Type'] = 'text/plain'
         return response
 
@@ -157,6 +175,7 @@ class HttpErrorResponseMiddleware:
 
 class UserAgentMiddleware:
     """Middleware to parse the user agent and add it to the request object."""
+
     def __init__(self, get_response=None):
         if get_response is not None:
             self.get_response = get_response
@@ -172,3 +191,23 @@ class UserAgentMiddleware:
         user_agent = parse_user_agent(request.META.get('HTTP_USER_AGENT', ''))
         request.user_agent = user_agent
         return request
+
+
+class RequestDataTooBigMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        try:
+            # Force Django to parse the request body early
+            _ = request.body
+        except RequestDataTooBig as e:
+            if is_ajax_request(request):
+                return json_response_error(
+                    {
+                        "error": "Request body too large",
+                        "details": str(e),
+                        "max_size": htk_setting('DATA_UPLOAD_MAX_MEMORY_SIZE'),
+                        "content_length": request.META.get("CONTENT_LENGTH"),
+                    },
+                    status=400,
+                )
+            else:
+                raise e


### PR DESCRIPTION
- Adds `RequestTooBig` Middleware  to detect when the `request.body` triggers a `RequestDataTooBig` exception and returns a custom `JSON 400` response. 
- The location where the request.body validation occurs: https://github.com/django/django/blob/5f30fd2358fd60a514bdba31594bfc8122f30167/django/http/request.py#L368-L375