### PR TITLE
feat: ✨ update auth middlewares to allow other auth middlewares

### DIFF
--- a/apps/accounts/middleware.py
+++ b/apps/accounts/middleware.py
@@ -1,6 +1,3 @@
-# Third Party (PyPI) Imports
-from social_django.middleware import SocialAuthExceptionMiddleware
-
 # Django Imports
 from django.contrib.auth import (
     authenticate,
@@ -9,14 +6,17 @@ from django.contrib.auth import (
 from django.http import HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 
+# Django Extensions Imports
+from social_django.middleware import SocialAuthExceptionMiddleware
+
 # HTK Imports
 from htk.api.utils import json_response_forbidden
 from htk.apps.accounts.utils.auth import login_authenticated_user
 from htk.apps.accounts.utils.general import (
     authenticate_user_by_basic_auth_credentials,
-    parse_authorization_header,
 )
 from htk.utils import htk_setting
+from htk.utils.request import parse_authorization_header
 
 
 # isort: off

--- a/apps/accounts/middleware.py
+++ b/apps/accounts/middleware.py
@@ -124,8 +124,8 @@ class HtkBasicAuthMiddleware(BaseHtkAuthMiddleware):
 
 
 class HtkUserTokenAuthMiddleware(BaseHtkAuthMiddleware):
-    """Custom Authentication Middleware to attempt logging in with a securely generated
-    token
+    """Custom Authentication Middleware to attempt logging in with
+    a securely generated token.
 
     Tokens are checked in the following order:
     - HTTP `Authorization` header
@@ -139,7 +139,7 @@ class HtkUserTokenAuthMiddleware(BaseHtkAuthMiddleware):
     def process_request(self, request):
         super().process_request(request)
 
-        token_type, token = self._parse_authorization_header(request)
+        token_type, token = parse_authorization_header(request)
 
         if token_type == 'Bearer':
             # The token is in the `Authorization` header
@@ -147,13 +147,13 @@ class HtkUserTokenAuthMiddleware(BaseHtkAuthMiddleware):
             auth_user = authenticate(request=request, token=token)
 
         elif 'token' in request.GET:
-            # implicit authenication token using URL params
+            # Implicit authentication using URL params
             self.is_explicit_auth = True
             token = request.GET['token']
             auth_user = authenticate(request=request, token=token)
 
         else:
-            # and give a chance for other auth middlewares to work
+            # Give a chance for other auth middlewares to work
             self.is_explicit_auth = False
             auth_user = None
 
@@ -164,10 +164,11 @@ class HtkSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
     def get_redirect_uri(self, request, exception):
         """Redirect to LOGIN_ERROR_URL by default
         Otherwise, go to the SOCIAL_AUTH_<STRATEGY>_LOGIN_ERROR_URL for that backend
-        provider if specified
+        provider if specified.
 
-        However, if user is logged in when the exception occurred, it is a connection
-        failure. Therefore, always go to account settings page or equivalent
+        However, if user is logged in when the exception occurred,
+        it is a connection failure.
+        Therefore, always go to account settings page or equivalent.
         """
         default_url = super(
             HtkSocialAuthExceptionMiddleware, self

--- a/apps/accounts/utils/general.py
+++ b/apps/accounts/utils/general.py
@@ -100,8 +100,8 @@ def set_random_password(user, password_length=16):
 
 def email_to_username_hash(email):
     """Convert emails to hashed versions where we store them in the username field
-    We can't just store them directly, or we'd be limited to Django's username <= 30
-    chars limit, which is really too small for arbitrary emails
+    We can't just store them directly, or we'd be limited to Django's username <= 30 chars limit,
+    which is really too small for arbitrary emails.
 
     From: https://github.com/dabapps/django-email-as-username/blob/master/emailusernames/utils.py  # noqa: E501
     """
@@ -180,8 +180,8 @@ def get_user_by_email(email):
                 )
             except UserModel.MultipleObjectsReturned:
                 user = None
-                request = get_current_request()  # noqa: F841
-                rollbar.report_exc_info()
+                request = get_current_request()
+                rollbar.report_exc_info(request=request)
                 raise NonUniqueEmail(email)
             except UserModel.DoesNotExist:
                 # also check newly registered accounts
@@ -388,8 +388,8 @@ def associate_user_email(  # noqa: C901
                         sender=email_sender,
                     )
                 except Exception:
-                    request = get_current_request()  # noqa: F841
-                    rollbar.report_exc_info()
+                    request = get_current_request()
+                    rollbar.report_exc_info(request=request)
             else:
                 pass
         else:

--- a/apps/accounts/utils/general.py
+++ b/apps/accounts/utils/general.py
@@ -2,7 +2,6 @@
 import base64
 import hashlib
 import time
-import typing as T
 
 # Third Party (PyPI) Imports
 import rollbar
@@ -12,7 +11,6 @@ from django.contrib.auth import (
     authenticate,
     get_user_model,
 )
-from django.http import HttpRequest
 from django.utils.http import (
     base36_to_int,
     int_to_base36,
@@ -503,34 +501,3 @@ def resolve_encrypted_uid(encrypted_uid):
     except UserModel.DoesNotExist:
         user = None
     return user
-
-
-def parse_authorization_header(
-    request: HttpRequest,
-) -> tuple[T.Optional[str], T.Optional[str]]:
-    """Parse the authorization header from the request
-
-    Expected format: `<token_type> <token>`
-
-    Examples:
-    - `Authorization: Bearer <token>`
-    - `Authorization: Basic <credentials>`
-
-    Returns:
-    - `token_type`: The type of token, e.g. `Bearer` or `Basic`
-    - `token`: The token
-    """
-    token = None
-    token_type = None
-
-    if 'HTTP_AUTHORIZATION' in request.META:
-        auth_header = request.META['HTTP_AUTHORIZATION']
-        parts = auth_header.split()
-        if len(parts) == 2:
-            token_type, token = parts
-        else:
-            pass
-    else:
-        pass
-
-    return token_type, token

--- a/utils/request.py
+++ b/utils/request.py
@@ -1,5 +1,9 @@
 # Python Standard Library Imports
 import re
+import typing as T
+
+# Django Imports
+from django.http import HttpRequest
 
 # HTK Imports
 from htk.utils import htk_setting
@@ -193,3 +197,34 @@ def is_allowed_host(host):
             if allowed:
                 break
     return allowed
+
+
+def parse_authorization_header(
+    request: HttpRequest,
+) -> tuple[T.Optional[str], T.Optional[str]]:
+    """Parse the authorization header from the request
+
+    Expected format: `<token_type> <token>`
+
+    Examples:
+    - `Authorization: Bearer <token>`
+    - `Authorization: Basic <credentials>`
+
+    Returns:
+    - `token_type`: The type of token, e.g. `Bearer` or `Basic`
+    - `token`: The token
+    """
+    token = None
+    token_type = None
+
+    if 'HTTP_AUTHORIZATION' in request.META:
+        auth_header = request.META['HTTP_AUTHORIZATION']
+        parts = auth_header.split()
+        if len(parts) == 2:
+            token_type, token = parts
+        else:
+            pass
+    else:
+        pass
+
+    return token_type, token


### PR DESCRIPTION
## Description

The main purpose of this PR is to give room to custom authentication middlewares in the projects.

The middlewares were cutting off the execution and giving forbidden errors other than the `Bearer` and `Basic` auth token types.

Also getting the `token_type` and `token` from `HTTP_AUTHORIZATION` is made a utility function to keep the code DRY.