### PR TITLE
fix: 🔧  related name for `organization members`

### DIFF
--- a/apps/organizations/models.py
+++ b/apps/organizations/models.py
@@ -236,7 +236,7 @@ class BaseAbstractOrganization(HtkBaseModel, GoogleOrganizationMixin):
 
 class BaseAbstractOrganizationMember(HtkBaseModel):
     organization = fk_organization(related_name='members', required=True)
-    user = fk_user(related_name='organizations', required=True)
+    user = fk_user(related_name='members', required=True)
     role = models.PositiveIntegerField(
         default=OrganizationMemberRoles.MEMBER.value,
         choices=get_organization_member_role_choices(),


### PR DESCRIPTION
- Fixes the incorrect `related_name` for the `user foreign key` on the `organization member`. 