### PR TITLE
fix: 🔧 uses `published_at` as the key when ordering `releases`

### DIFF
--- a/lib/github/models/release.py
+++ b/lib/github/models/release.py
@@ -52,8 +52,8 @@ class BaseRelease(models.Model):
 
     class Meta:
         abstract = True
-        ordering = ["-version"]
-        get_latest_by = "version"
+        ordering = ["-published_at"]
+        get_latest_by = "published_at"
         verbose_name = _("release")
 
     def __str__(self):

--- a/lib/github/utils.py
+++ b/lib/github/utils.py
@@ -6,9 +6,6 @@ from github import Github
 from github.GitRelease import GitRelease
 from github.Repository import Repository
 
-# Django Imports
-from django.conf import settings
-
 # HTK Imports
 from htk.utils import (
     htk_setting,
@@ -106,9 +103,6 @@ def sync_repository_releases(
             repository=repo_name,
         )
     }
-    from htk.utils.debug import slack_debug
-
-    # slack_debug(f'Syncing {len(releases)} releases from {repo_name}')
 
     for github_release in releases:
         existing_release = existing_releases.get(github_release.tag_name)


### PR DESCRIPTION
- Removes the invalid ordering key called `version` which doesn't exist on the model and uses `published_at` instead. 
- Cleans up leftover code and imports.