### PR TITLE
fix(meta): Updating meta for string-based values

### DIFF
--- a/view_helpers.py
+++ b/view_helpers.py
@@ -335,25 +335,26 @@ def _update_meta_content(meta_type, value, update_type='set', data=None):
     if data is None:
         data = {}
     meta = data.get('meta', {}).get(meta_type)
-    if meta:
-        # Check if this meta type is list-based by looking for 'inverted' key
-        if 'inverted' in meta:
-            # Handle list-based meta types (e.g. title, description, keywords)
-            if type(value) in (list, tuple):
-                values_list = value
-            else:
-                values_list = [value]
-            if update_type == 'set':
-                meta['inverted'] = values_list
-            elif update_type == 'add':
-                meta['inverted'] += values_list
-            else:
-                # unknown update_type
-                pass
+    if type(meta) == dict:
+        # Handle list-based meta types (e.g. title, description, keywords)
+        if type(value) in (list, tuple):
+            values_list = value
         else:
-            # Handle string-based meta types (e.g. canonical_url, image)
-            data['meta'][meta_type] = value
+            values_list = [value]
+        if update_type == 'set':
+            meta['inverted'] = values_list
+        elif update_type == 'add':
+            meta['inverted'] += values_list
+        else:
+            # unknown update_type
+            pass
+    elif type(meta) == str:
+        # Handle string-based meta types (e.g. canonical_url, image).
+        # This assumes that the meta value was initialized with a default string,
+        # including an empty string.
+        data['meta'][meta_type] = value
     else:
+        # unknown meta value type
         pass
 
 


### PR DESCRIPTION
The bug affected new methods `set_meta_image` and `set_meta_canonical_url` which would only work if there was a previous non-empty string value.

### Testing

Locally tested the `set_meta_image` and `set_meta_canonical_url` methods on a profile view.

```
<title>Jonathan Tsai | Athletes | BawsHuman</title>
<meta property="og:title" content="Jonathan Tsai | Athletes | BawsHuman" />
<meta name="twitter:title" content="Jonathan Tsai | Athletes | BawsHuman" />
<meta name="description" content="View Jonathan Tsai&#x27;s activity on BawsHuman. Transforming humanity into its ultimate form." />
<meta property="og:description" content="View Jonathan Tsai&#x27;s activity on BawsHuman. Transforming humanity into its ultimate form." />
<meta name="twitter:description" content="View Jonathan Tsai&#x27;s activity on BawsHuman. Transforming humanity into its ultimate form." />
<meta property="og:url" content="https://REDACTED.bawshuman.com/athlete/jontsai" />
<meta name="twitter:url" content="https://REDACTED.bawshuman.com/athlete/jontsai" />
<meta name="keywords" content="Jonathan Tsai,athletes,performance coaching,personal training" />
<meta property="og:image" content="https://www.gravatar.com/avatar/880d232af0f41ab6537024950dbc7753?s=80&amp;default=mm" />
<meta name="twitter:image" content="https://www.gravatar.com/avatar/880d232af0f41ab6537024950dbc7753?s=80&amp;default=mm" />
<meta name="twitter:card" content="summary_large_image" />
```