### PR TITLE
fix(rollbar): Update 2.26.x version handling in Rollbar templates

### DIFF
--- a/templates/fragments/js/rollbar/rollbar.html
+++ b/templates/fragments/js/rollbar/rollbar.html
@@ -3,7 +3,7 @@ https://rollbar.com/docs/notifier/rollbar.js/
 {% endcomment %}
 
 {% if rollbar_js_version %}
-{% if rollbar_js_version == '2.26' %}
+{% if rollbar_js_version|slice:":4" == '2.26' %}
 {% include 'fragments/js/rollbar/v2.26.x.html' %}
 {% elif rollbar_js_version == '2.25' %}
 {% include 'fragments/js/rollbar/v2.25.x.html' %}

--- a/templates/fragments/js/rollbar/v2.26.x.html
+++ b/templates/fragments/js/rollbar/v2.26.x.html
@@ -1,6 +1,12 @@
 <script>
 // rollbar_js_version: {{ rollbar_js_version }} (expected: 2.26.x)
 
+var _rollbarJsVersion = '{{ rollbar_js_version }}';
+// Ensure version has patch number, fallback to 2.26.0 if not
+if (!_rollbarJsVersion.match(/^\d+\.\d+\.\d+$/)) {
+  _rollbarJsVersion = '2.26.0';
+}
+
 var _rollbarIgnoredUncaughtExceptionClasses = {% if rollbar.ignored_uncaught_exception_classes %}{{ rollbar.ignored_uncaught_exception_classes|safe }}{% else %}[]{% endif %};
 
 var _rollbarIgnoredMessagesRegexes = [
@@ -10,6 +16,7 @@ var _rollbarIgnoredMessagesRegexes = [
 ];
 
 var _rollbarConfig = {
+  rollbarJsUrl: 'https://cdn.rollbar.com/rollbarjs/refs/tags/v' + _rollbarJsVersion + '/rollbar.min.js',
   accessToken: '{{ rollbar.tokens.post_client_item }}',
   // verbose: log to console.log, as well as Rollbar
   verbose: {% if rollbar.environment == 'production' %}false{% else %}true{% endif %},


### PR DESCRIPTION
There was a bug that prevented the loading of `rollbar.min.js` file on Django app. 

![Screenshot 2025-06-10 at 11 31 21 PM](https://github.com/user-attachments/assets/c5af2f2f-4245-4126-8cc4-b9bfb78126a3)

In the [bawshuman-django repo](https://github.com/BawsHuman/bawshuman-django/blob/224068e4c36bcbee88f5ad4a56f21c4f44d8f563/baws/templates/baws/fragments/js/common.html#L1), we specify the full version "2.26.4". But in the rollbar.html file, we are doing a strict equality check to "2.26". This causes the `v1.x.html` template to load instead of `v2.26.x.html`, causing the wrong CDN URL to be used.

This fix allows specifying the version for 2.26.x with either "2.26" which will fallback to "2.26.0", or you can specify a specific patch such as "2.26.4".