### PR TITLE
fix 🐛 Update import for InvitationStatus

### DIFF
--- a/apps/invitations/utils.py
+++ b/apps/invitations/utils.py
@@ -5,6 +5,6 @@ from htk.utils.enums import get_enum_choices
 
 
 def get_invitation_status_choices():
-    from mesh.enums import InvitationStatus
+    from htk.apps.invitations.enums import InvitationStatus
     choices = get_enum_choices(InvitationStatus)
     return choices


### PR DESCRIPTION
- Update import for the InvitationStatus from apps invitation status instead of error throwing mesh.