### PR TITLE
feat: Add `display` property to `HtkEnum` for symbolic name retrieval

### DIFF
--- a/utils/enums.py
+++ b/utils/enums.py
@@ -10,6 +10,10 @@ from htk.utils import htk_setting
 
 
 class HtkEnum(Enum):
+    @property
+    def display(self):
+        return get_enum_symbolic_name(self)
+
     def json_encode(self):
         """json_encode Generate a valid dict for JSON
 


### PR DESCRIPTION
This is especially helpful for displaying human-readable enums within Django templates. For example, let's say there's an object with a `status` enum property of a Model. So we define a `status_enum` on the model, and then within the Django template, we can use `model_instance.status_enum.display` to render the human-readable string.