### PR TITLE
feat: ✨ adds field `allow_free_response` on `AssessmentQuestionAnswerOption` model

### DIFF
--- a/apps/assessments/models.py
+++ b/apps/assessments/models.py
@@ -88,6 +88,7 @@ class AbstractAssessmentQuestionAnswerOption(models.Model):
         on_delete=models.CASCADE,
     )
     text = models.CharField(max_length=255)
+    allow_free_response = models.BooleanField(default=False)
     # Indicates if this choice is the correct answer
     is_correct = models.BooleanField(default=False)
     # Optional color for controlling the UI


### PR DESCRIPTION
- Adds an `allow_free_response boolean` field to `AbstractAssessmentQuestionAnswerOption` to enable conditional free-text input for specific multiple-choice options.
- Enables "Other (please specify)" style options in multiple-choice questions where users can:
  - Select the option (e.g., "Other")
  - Provide additional free-text details in the same response