### PR TITLE
fix(organizations): update user.organizations to user.members in get_user_organizations_with_attribute

### DIFF
--- a/apps/organizations/utils.py
+++ b/apps/organizations/utils.py
@@ -48,7 +48,7 @@ def get_organization_team_member_role_choices():
 
 
 def get_user_organizations_with_attribute(user, key):
-    organizations = user.organizations.filter(
+    organizations = user.members.filter(
         active=True, organization__attributes__key=key
     ).exclude(organization__attributes__value=None)
     return organizations


### PR DESCRIPTION
## Problem

`get_user_organizations_with_attribute()` calls `user.organizations.filter(...)`, but the `related_name` on `BaseAbstractOrganizationMember.user` was changed from `'organizations'` to `'members'` in cb44779.

This causes:
```
AttributeError: 'User' object has no attribute 'organizations'
```

## Fix

Update `user.organizations` → `user.members` to match the current `related_name`.